### PR TITLE
Change Abstract Test Suite to Abstract Test

### DIFF
--- a/core/standard/abstract_tests/core/ATS_fc-md-op.adoc
+++ b/core/standard/abstract_tests/core/ATS_fc-md-op.adoc
@@ -1,7 +1,7 @@
 [[ats_core_fc-md-op]]
 [width="90%",cols="2,6a"]
 |===
-^|*Abstract Test Suite {counter:ats-id}* |*/ats/core/fc-md-op*
+^|*Abstract Test {counter:ats-id}* |*/ats/core/fc-md-op*
 ^|Test Purpose |Validate that information about the Collections can be retrieved from the expected location.
 ^|Requirement |<<req_core_fc-md-op,/req/core/fc-md-op>>
 ^|Test Method |. Issue an HTTP GET request to the URL {root}/collections


### PR DESCRIPTION
There seems to be a typo in the ATS:

![image](https://user-images.githubusercontent.com/11427611/66394739-23898900-e9d6-11e9-92e0-b41ee80bc230.png)
