### PR TITLE
Update description for status code 406

### DIFF
--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -226,7 +226,7 @@ The *Status Codes* listed in <<status_codes>> are of particular relevance to imp
 |`403` |The server understood the request, but is refusing to fulfill it. While status code `401` indicates missing or bad authentication, status code `403` indicates that authentication is not the issue, but the client is not authorized to perform the requested operation on the resource.
 |`404` |The requested resource does not exist on the server. For example, a path parameter had an incorrect value.
 |`405` |The request method is not supported. For example, a POST request was submitted, but the resource only supports GET requests.
-|`406` |The `Accept` header submitted in the request did not support any of the media types supported by the server for the requested resource.
+|`406` |Content negotiation failed. For example, the `Accept` header submitted in the request did not support any of the media types supported by the server for the requested resource.
 |`500` |An internal error occurred in the server.
 !===
 


### PR DESCRIPTION
A server could also return status code 406 Not Acceptable when the language negotiation (mentioned in 7.10. String internationalization) or the content negotiation based on `Accept-Charset` or `Accept-Encoding` fails.