### PR TITLE
relax use of "distribution"

### DIFF
--- a/core/standard/clause_0_front_material.adoc
+++ b/core/standard/clause_0_front_material.adoc
@@ -15,7 +15,7 @@ The API building blocks specified in this standard are consistent with the archi
 
 This standard specifies discovery and query operations that are implemented using the HTTP GET method. Support for additional methods (in particular POST, PUT, DELETE, PATCH) will be specified in additional parts.
 
-Discovery operations enable clients to interrogate the API to determine its capabilities and retrieve information about this distribution of the dataset, including the API definition and metadata about the feature collections provided by the API.
+Discovery operations enable clients to interrogate the API, including the API definition and metadata about the feature collections provided by the API, to determine the capabilities of the API and retrieve information about available distributions of the dataset.
 
 Query operations enable clients to retrieve features from the underlying data store based upon simple selection criteria, defined by the client.
 

--- a/core/standard/clause_1_scope.adoc
+++ b/core/standard/clause_1_scope.adoc
@@ -2,6 +2,6 @@
 
 This document specifies the behavior of Web APIs that provide access to features in a dataset in a manner independent of the underlying data store. This standard defines discovery and query operations.
 
-Discovery operations enable clients to interrogate the API to determine its capabilities and retrieve information about this distribution of the dataset, including the API definition and metadata about the feature collections provided by the API.
+Discovery operations enable clients to interrogate the API, including the API definition and metadata about the feature collections provided by the API, to determine the capabilities of the API and retrieve information about available distributions of the dataset.
 
 Query operations enable clients to retrieve features from the underlying data store based upon simple selection criteria, defined by the client.

--- a/core/standard/clause_5_conventions.adoc
+++ b/core/standard/clause_5_conventions.adoc
@@ -42,7 +42,7 @@ In addition the following link relation types are used for which no applicable r
 
 * **conformance**: Refers to a resource that identifies the specifications that the link's context conforms to.
 
-* **data**: Indicates that the link's context is a distribution of a dataset that is an API and refers to the root resource of the dataset in the API.
+* **data**: Refers to the root resource of a dataset in an API.
 
 Each resource representation includes an array of links. Implementations are free to add additional links for all resources provided by the API. For example, an **enclosure** link could reference a bulk download of a collection. Or a **related** link on a feature could reference a related feature.
 
@@ -117,4 +117,3 @@ URL `https://data.example.org/mypath` for the production server.
 ==== Reusable OpenAPI components
 
 Reusable components for OpenAPI definitions for implementations of OGC API Features are referenced from this document.
-

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -5,13 +5,13 @@
 
 include::requirements/requirements_class_core.adoc[]
 
-A server that implements this requirements class provides access to the features in a link:https://www.w3.org/TR/vocab-dcat/#class-dataset[dataset]. In other words, the API is a link:https://www.w3.org/TR/vocab-dcat/#class-distribution[distribution] of that dataset. A file download, for example, would be another distribution.
+A server that implements this requirements class provides access to the features in a link:https://www.w3.org/TR/vocab-dcat/#class-dataset[dataset].
 
 NOTE: Other parts of this standard may define API extensions that support multiple datasets. The statement that the features are from "a dataset" is not meant to preclude such extensions. It just reflects that this document does not specify how the API publishes features or other spatial data from multiple datasets.
 
 The entry point is a `Landing page` (path `/`).
 
-NOTE: All paths (e.g., `/`) are relative to the base URL of the distribution of the dataset. If the API covers other resources beyond those specified in this document, the landing page may also be, for example, a sub-resource of the base URL of the API.
+NOTE: All paths (e.g., `/`) are relative. If the API covers other resources beyond those specified in this document, the landing page may also be, for example, a sub-resource of the base URL of the API.
 
 The `Landing page` provides links to:
 


### PR DESCRIPTION
... to avoid a tight coupling with DCAT (2014) where the definitions have changed in DCAT 2

resolves #305