### PR TITLE
Fix links to RFCs

### DIFF
--- a/core/standard/clause_5_conventions.adoc
+++ b/core/standard/clause_5_conventions.adoc
@@ -48,11 +48,11 @@ Each resource representation includes an array of links. Implementations are fre
 
 === Use of HTTPS
 
-For simplicity, this document in general only refers to the HTTP protocol. This is not meant to exclude the use of HTTPS and simply is a shorthand notation for "HTTP or HTTPS." In fact, most servers are expected to use <<rfc2818,HTTPS>>, not <<rc2616,HTTP>>.
+For simplicity, this document in general only refers to the HTTP protocol. This is not meant to exclude the use of HTTPS and simply is a shorthand notation for "HTTP or HTTPS." In fact, most servers are expected to use <<rfc2818,HTTPS>>, not <<rfc2616,HTTP>>.
 
 === HTTP URIs
 
-This document does not restrict the lexical space of URIs used in the API beyond the requirements of the <<rc2616,HTTP>> and <<rc3986,URI Syntax>> IETF RFCs. If URIs include reserved characters that are delimiters in the URI subcomponent, these have to be percent-encoded. See Clause 2 of <<rfc3986,RFC 3986>> for details.
+This document does not restrict the lexical space of URIs used in the API beyond the requirements of the <<rfc2616,HTTP>> and <<rfc3986,URI Syntax>> IETF RFCs. If URIs include reserved characters that are delimiters in the URI subcomponent, these have to be percent-encoded. See Clause 2 of <<rfc3986,RFC 3986>> for details.
 
 === API definition
 


### PR DESCRIPTION
The links to the RFCs had a typo.