### PR TITLE
CQL functions: functions vs. function call expressions

### DIFF
--- a/extensions/cql/standard/requirements/functions/REQ_functions-json.adoc
+++ b/extensions/cql/standard/requirements/functions/REQ_functions-json.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/functions/functions-json* 
-^|A |A server that implements the <<rc_functions,Functions>> requirement class and also implements this requirement shall be able to parse a function encoded as JSON according to the following JSON Schema fragment which extends and ammends the <<rc_simple_cql,Simple CQL>> JSON Schema:
+^|A |A server that implements the <<rc_functions,Functions>> requirement class and also implements this requirement shall be able to parse a function call expression encoded as JSON according to the following JSON Schema fragment which extends and ammends the <<rc_simple_cql,Simple CQL>> JSON Schema:
 
 ----
    "function": {

--- a/extensions/cql/standard/requirements/functions/REQ_functions-text.adoc
+++ b/extensions/cql/standard/requirements/functions/REQ_functions-text.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/functions/functions-text* 
-^|A |A server that implements the <<rc_functions,Functions>> requirement class and also implements this requirement shall be able to parse a function encoded as a text string that validates against the BNF production fragment in requirement <<req_enhanced_functions,Functions>>.
+^|A |A server that implements the <<rc_functions,Functions>> requirement class and also implements this requirement shall be able to parse a function call expression encoded as a text string that validates against the BNF production fragment in requirement <<req_enhanced_functions,Functions>>.
 |===


### PR DESCRIPTION
CQL Functions: Clarify req 28 and 29 being about parsing function call expressions, not actual functions (not definitions)