### PR TITLE
Update use of CRS and TRS

### DIFF
--- a/core/openapi/schemas/extent.yaml
+++ b/core/openapi/schemas/extent.yaml
@@ -83,7 +83,7 @@ properties:
         items:
           description: |-
             Begin and end times of the time interval. The timestamps
-            are in the coordinate reference system specified in `trs`. By default
+            are in the temporal reference system specified in `trs`. By default
             this is the Gregorian calendar.
           type: array
           minItems: 2
@@ -97,9 +97,9 @@ properties:
             - null
       trs:
         description: |-
-          Coordinate reference system of the coordinates in the temporal extent
-          (property `interval`). The default reference system is the Gregorian calendar.
-          In the Core this is the only supported temporal reference system.
+          Temporal reference system of the timestamps in the temporal extent
+          (property `interval`). The default TRS is the Gregorian calendar.
+          In the Core this is the only supported TRS.
           Extensions may support additional temporal reference systems and add
           additional enum values.
         type: string

--- a/core/standard/abstract_tests/core/ATS_crs84.adoc
+++ b/core/standard/abstract_tests/core/ATS_crs84.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Abstract Test {counter:ats-id}* |*/conf/core/crs84*
-^|Test Purpose |Validate that all spatial geometries provided through the API are in the CRS84 spatial reference system unless otherwise requested by the client.
+^|Test Purpose |Validate that all spatial geometries provided through the API are in the CRS84 coordinate reference system unless otherwise requested by the client.
 ^|Requirement |<<req_core_crs84,/req/core/crs84>>
 ^|Test Method |. Do not specify a coordinate reference system in any request. All spatial data should be in the CRS84 reference system.
 . Validate retrieved spatial data using the CRS84 reference system.

--- a/core/standard/clause_4_terms_and_definitions.adoc
+++ b/core/standard/clause_4_terms_and_definitions.adoc
@@ -37,7 +37,7 @@ NOTE: link:https://www.w3.org/TR/dwbp/#APIHttpVerbs[Best Practice 24: Use Web St
 API::
   Application Programming Interface
 CRS::
-  Coordinate Reference Systems
+  Coordinate Reference System
 HTTP::
   Hypertext Transfer Protocol
 HTTPS::
@@ -46,6 +46,8 @@ IANA::
   Internet Assigned Numbers Authority
 OGC::
   Open Geospatial Consortium
+TRS::
+  Temporal Reference System
 URI::
   Uniform Resource Identifier
 YAML::

--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -37,7 +37,7 @@ Some examples for cases that are out-of-scope of GeoJSON are:
 
 * Geometries that include non-linear curve interpolations that cannot be simplified (e.g., use of arcs in authoritative geometries),
 
-* Geometries that have to be represented in a coordinate reference system that is not based on WGS 84 longitude/latitude (e.g., an authoritative national reference system), or
+* Geometries that have to be represented in a coordinate reference system (CRS) that is not based on WGS 84 longitude/latitude (e.g., an authoritative national CRS), or
 
 * Features that have more than one geometric property.
 

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -37,7 +37,7 @@ Accessing `Collections` using HTTP GET returns a response that contains at least
 
 * A local identifier for the collection that is unique for the dataset;
 
-* A list of coordinate reference systems (CRS) in which geometries may be returned by the server: the first CRS is the default coordinate reference system (in the _Core_, the default is always WGS 84 with axis order longitude/latitude);
+* A list of coordinate reference systems in which geometries may be returned by the server: the first CRS is the default CRS (in the _Core_, the default CRS is always WGS 84 with axis order longitude/latitude);
 
 * An optional title and description for the collection;
 
@@ -483,8 +483,8 @@ properties:
           crs:
             description: >-
               Coordinate reference system of the coordinates in the spatial extent
-              (property `bbox`). The default reference system is WGS 84 longitude/latitude.
-              In the Core this is the only supported coordinate reference system.
+              (property `bbox`). The default CRS is WGS 84 longitude/latitude.
+              In the Core this is the only supported CRS.
               Extensions may support additional coordinate reference systems and add
               additional enum values.
             type: string
@@ -508,7 +508,7 @@ properties:
             items:
               description: >-
                 Begin and end times of the time interval. The timestamps
-                are in the coordinate reference system specified in `trs`. By default
+                are in the temporal reference system specified in `trs`. By default
                 this is the Gregorian calendar.
               type: array
               minItems: 2
@@ -522,9 +522,9 @@ properties:
                 - null
           trs:
             description: >-
-              Coordinate reference system of the coordinates in the temporal extent
-              (property `interval`). The default reference system is the Gregorian calendar.
-              In the Core this is the only supported temporal reference system.
+              Temporal reference system of the timestamps in the temporal extent
+              (property `interval`). The default TRS is the Gregorian calendar.
+              In the Core this is the only supported TRS.
               Extensions may support additional temporal reference systems and add
               additional enum values.
             type: string


### PR DESCRIPTION
Update the list of abbrevations, update the use of CRS and TRS,
update the description of the temporal extent property.

In some places the original text seemed to mix up coordinate reference system and temporal reference system.