### PR TITLE
Update links to OpenAPI specification

### DIFF
--- a/core/standard/abstract_tests/oas30/ATS_completeness.adoc
+++ b/core/standard/abstract_tests/oas30/ATS_completeness.adoc
@@ -4,5 +4,5 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/oas30/completeness* 
 ^|Test Purpose |Verify the completeness of an OpenAPI document. 
 ^|Requirement |<<req_oas30_completeness,/req/oas30/completeness>>
-^|Test Method |Verify that for each operation, the OpenAPI document describes all link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#httpCodes[HTTP Status Codes] and link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject[Response Objects] that the API uses in responses.
+^|Test Method |Verify that for each operation, the OpenAPI document describes all link:http://spec.openapis.org/oas/v3.0.3#http-status-codes[HTTP Status Codes] and link:http://spec.openapis.org/oas/v3.0.3#responseObject[Response Objects] that the API uses in responses.
 |===

--- a/core/standard/abstract_tests/oas30/ATS_exception-codes.adoc
+++ b/core/standard/abstract_tests/oas30/ATS_exception-codes.adoc
@@ -4,5 +4,5 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/oas30/exceptions-codes* 
 ^|Test Purpose |Verify that the OpenAPI document fully describes potential exception codes. 
 ^|Requirement |<<req_oas30_exceptions-codes,/req/oas30/exceptions-codes>>
-^|Test Method |Verify that for each operation, the OpenAPI document describes all link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#httpCodes[HTTP Status Codes] that may be generated.
+^|Test Method |Verify that for each operation, the OpenAPI document describes all link:http://spec.openapis.org/oas/v3.0.3#http-status-codes[HTTP Status Codes] that may be generated.
 |===

--- a/core/standard/clause_9_oas.adoc
+++ b/core/standard/clause_9_oas.adoc
@@ -2,7 +2,7 @@
 
 === Basic requirements
 
-Servers conforming to this requirements class define their API by an link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oasDocument[OpenAPI Document].
+Servers conforming to this requirements class define their API by an link:http://spec.openapis.org/oas/v3.0.3#openapi-document[OpenAPI Document].
 
 include::requirements/requirements_class_oas30.adoc[]
 
@@ -51,7 +51,7 @@ content:
 
 include::requirements/oas30/REQ_security.adoc[]
 
-The OpenAPI specification currently supports the following link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-scheme-object[security schemes]:
+The OpenAPI specification currently supports the following link:http://spec.openapis.org/oas/v3.0.3#security-scheme-object[security schemes]:
 
 * HTTP authentication,
 

--- a/core/standard/requirements/html/REQ_content.adoc
+++ b/core/standard/requirements/html/REQ_content.adoc
@@ -4,6 +4,6 @@
 ^|*Requirement {counter:req-id}* |*/req/html/content*
 ^|A |Every `200`-response of the server with the media type `text/html` SHALL be a link:https://www.w3.org/TR/html5/[HTML 5 document] that includes the following information in the HTML body:
 
-* all information identified in the schemas of the link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject[Response Object] in the HTML `<body>`, and
+* all information identified in the schemas of the link:http://spec.openapis.org/oas/v3.0.3#responseObject[Response Object] in the HTML `<body>`, and
 * all links in HTML `<a>` elements in the HTML `<body>`.
 |===

--- a/core/standard/requirements/oas30/REQ_completeness.adoc
+++ b/core/standard/requirements/oas30/REQ_completeness.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* | */req/oas30/completeness* 
-^|A |The OpenAPI definition SHALL specify for each operation all link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#httpCodes[HTTP Status Codes] and link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject[Response Objects] that the server uses in responses.
+^|A |The OpenAPI definition SHALL specify for each operation all link:http://spec.openapis.org/oas/v3.0.3#http-status-codes[HTTP Status Codes] and link:http://spec.openapis.org/oas/v3.0.3#responseObject[Response Objects] that the server uses in responses.
 ^|B |This includes the successful execution of an operation as well as all error situations that originate from the server.
 |===


### PR DESCRIPTION
Update links from v3.0.0 to v3.0.3 and from GitHub to published specification at http://spec.openapis.org/ .