### PR TITLE
Update support of Esri's "ArcGIS API for JavaScript"

### DIFF
--- a/implementations/README.adoc
+++ b/implementations/README.adoc
@@ -148,7 +148,7 @@ The columns for each part list the conformance classes of the standard that the 
 
 | link:clients/arcgis-js.md[ArcGIS API for JavaScript - OGCFeatureLayer]
 | `core`, `oas30`, `geojson`
-| -
+| `crs`
 | -
 | -
 |


### PR DESCRIPTION
Version 4.19 of the **ArcGIS API for JavaScript** (as of 4/22/2021) support part 2 of the **OGC API - Features** specification.