### PR TITLE
add/update definitions of resource / web resource

### DIFF
--- a/core/standard/annex_bibliography.adoc
+++ b/core/standard/annex_bibliography.adoc
@@ -13,3 +13,4 @@
 * [[DWBP]] World Wide Web Consortium (W3C): **Data on the Web Best Practices** [online]. Edited by B.F. Lóscio, C. Burle, N. Calegari. 2017 [viewed 2020-03-16]. Available at https://www.w3.org/TR/dwbp/
 * [[DCAT]] World Wide Web Consortium (W3C): **Data Catalog Vocabulary** [online]. Edited by R. Albertoni, D. Browning, S. Cox, A.G. Beltran, A. Perego, P. Winstanley. 2020 [viewed 2020-03-16]. Available at https://www.w3.org/TR/vocab-dcat/
 * [[OGCAPI]] Open Geospatial Consortium (OGC). *Welcome To The OGC APIs* [online, viewed 2020-03-16]. Available at http://www.ogcapi.org/
+* [[iso15836-2]] ISO 15836-2:2019, **Information and documentation — The Dublin Core metadata element set — Part 2: DCMI Properties and classes**

--- a/core/standard/clause_4_terms_and_definitions.adoc
+++ b/core/standard/clause_4_terms_and_definitions.adoc
@@ -26,11 +26,21 @@ NOTE: More details about the term 'feature' may be found in the <<SDWBP,W3C/OGC 
 ==== feature collection; collection
 a set of *features* from a *dataset*
 
+[[resource-def]]
+==== resource
+entity that might be identified (<<iso15836-2,Dublin Core Metadata Initiative - DCMI Metadata Terms>>)
+
+NOTE: The term "resource", when used in the context of an OGC API standard, should be understood to mean a <<web-resource-def,web resource>> unless otherwise indicated.
+
 [[webapi]]
 ==== Web API
 API using an architectural style that is founded on the technologies of the Web <<DWBP>>
 
 NOTE: link:https://www.w3.org/TR/dwbp/#APIHttpVerbs[Best Practice 24: Use Web Standards as the foundation of APIs] in the <<DWBP,W3C Data on the Web Best Practices>> provides more detail.
+
+[[web-resource-def]]
+==== web resource
+a **resource** that is identified by a HTTP URI.
 
 === Abbreviated terms
 

--- a/extensions/cql/standard/annex_bibliography.adoc
+++ b/extensions/cql/standard/annex_bibliography.adoc
@@ -9,3 +9,4 @@
 * [[ogc-link-relations]] Open Geospatial Consortium (OGC). **OGC Link Relation Type Register** [online, viewed 2021-06-10], Available at http://www.opengis.net/def/rel
 * [[OpenAPI]] OpenAPI Initiative (OAI). **OpenAPI Specification 3.0** [online]. 2020 [viewed 2020-03-16]. The latest patch version at the time of publication of this standard was 3.0.3, available at http://spec.openapis.org/oas/v3.0.3
 * [[rfc3986]] Internet Engineering Task Force (IETF). RFC 3986: **Uniform Resource Identifier (URI): Generic Syntax** [online]. Edited by T. Berners-Lee, R. Fielding, L. Masinter. [viewed 2020-03-16]. Available at http://tools.ietf.org/rfc/rfc3986.txt
+* [[iso15836-2]] ISO 15836-2:2019, **Information and documentation — The Dublin Core metadata element set — Part 2: DCMI Properties and classes**

--- a/extensions/cql/standard/clause_4_terms_and_definitions.adoc
+++ b/extensions/cql/standard/clause_4_terms_and_definitions.adoc
@@ -34,8 +34,14 @@ NOTE: As content of OGC API standards, a resource is typically published at an e
 a token that represents a property of a resource that can be used in a **filter expression**
 
 [[resource-def]]
-==== resource / web resource
-any information that can be named and is the intended conceptual target of a hypertext reference (https://www.ics.uci.edu/~fielding/pubs/dissertation/fielding_dissertation.pdf[Architectural Styles and the Design of Network-based Software Architectures])
+==== resource
+entity that might be identified (<<iso15836-2,Dublin Core Metadata Initiative - DCMI Metadata Terms>>)
+
+NOTE: The term "resource", when used in the context of an OGC API standard, should be understood to mean a <<web-resource-def,web resource>> unless otherwise indicated.
+
+[[web-resource-def]]
+==== web resource
+a **resource** that is identified by a HTTP URI.
 
 === Symbols
 


### PR DESCRIPTION
Updated in part 3, added in part 1. 

closes #558

see also opengeospatial/ogcapi-common#240

Note that there is a small difference between the current update in Common. Instead of "identified by an IRI" I have used "identified by a HTTP URI" since IRIs/URIs in other schemes identify non-web resources (e.g. UUIDs or e-mailboxes).