### PR TITLE
Issue 602: Using binary comparison operators to evaluate simple temporal expressions using time instants.

### DIFF
--- a/extensions/cql/standard/clause_8_simple_cql.adoc
+++ b/extensions/cql/standard/clause_8_simple_cql.adoc
@@ -111,8 +111,8 @@ POLYGON((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925,
 ----
 * temporal geometry (instants, text)
 ----
-DATE("1969-07-20")
-TIMESTAMP("1969-07-20T20:17:40Z")
+DATE('1969-07-20')
+TIMESTAMP('1969-07-20T20:17:40Z')
 ----
 * temporal geometry (instants, JSON)
 [source,JSON]
@@ -122,9 +122,9 @@ TIMESTAMP("1969-07-20T20:17:40Z")
 ----
 * temporal geometry (intervals, text)
 ----
-INTERVAL("1969-07-16", "1969-07-24")
-INTERVAL("1969-07-16T05:32:00Z", "1969-07-24T16:50:35Z")
-INTERVAL("2019-09-09", "..")
+INTERVAL('1969-07-16', '1969-07-24')
+INTERVAL('1969-07-16T05:32:00Z', '1969-07-24T16:50:35Z')
+INTERVAL('2019-09-09', '..')
 ----
 * temporal geometry (intervals, JSON)
 [source,JSON]
@@ -179,6 +179,8 @@ avg(windSpeed)
 
 include::requirements/simple-cql/REQ_binary-comparison-predicate.adoc[]
 
+include::recommendations/simple-sql/PER_time-instant-comparisons.adoc[]
+
 [[example_8_3]]
 .Binary comparison predicates
 ====
@@ -216,6 +218,17 @@ balance-150.0 > 0
     { "-": [ { "property": "balance" }, 150.0 ] },
     0
   ]
+}
+----
+
+----
+updated >= date('1970-01-01')
+----
+
+[source,JSON]
+----
+{
+  "gte": [ { "property": "updated" }, { "date": "1970-01-01" } ]
 }
 ----
 ====

--- a/extensions/cql/standard/recommendations/simple-sql/PER_time-instant-comparisons.adoc
+++ b/extensions/cql/standard/recommendations/simple-sql/PER_time-instant-comparisons.adoc
@@ -1,0 +1,6 @@
+[[per_simple-cql_time-instant-comparison]]
+[width="90%",cols="2,6a"]
+|===
+^|*Permission {counter:per-id}* |*/per/simple-cql/time-instant-comparison* +
+2+|In lieu of using the formal <<temporal-operators,temporal operators>>, binary comparion operators may be used evaluate simple temporal predicates (rule: `binaryComparisonPredicate`) involving time instants (rule: `instantLiteral`).
+|===


### PR DESCRIPTION
Even though this is evident in the BNF, add a permission (and examples) that states that instead of using temporal operators, binary comparison operators may be used evaluate simple temporal predicates involving time instants.