### PR TITLE
Issue-579: Bug in CQL2 JSON not allowing comparison operators to be used to evaluate temporal predicates involving time instants.

### DIFF
--- a/extensions/cql/standard/clause_9_enhanced.adoc
+++ b/extensions/cql/standard/clause_9_enhanced.adoc
@@ -260,6 +260,8 @@ All temporal geometries are in the Gregorian Calendar. This is a deliberate rest
 
 The temporal operators in CQL2 are based on the definitions in the <<owl-time,W3C/OGC Time Ontology in OWL>>. 
 
+NOTE: <<per_basic-cql2_time-instant-comparison,Simple temporal prediates>> can also be evaluated using the <<basic-cql2_comparison-predicates,standard comparison operators>>.
+
 The following table specifies the definition of the temporal operators where both operands may be instants or intervals, including mixed combinations.
 
 [[temporal-operators-1]]

--- a/extensions/cql/standard/clause_9_enhanced.adoc
+++ b/extensions/cql/standard/clause_9_enhanced.adoc
@@ -260,7 +260,7 @@ All temporal geometries are in the Gregorian Calendar. This is a deliberate rest
 
 The temporal operators in CQL2 are based on the definitions in the <<owl-time,W3C/OGC Time Ontology in OWL>>. 
 
-NOTE: <<per_basic-cql2_time-instant-comparison,Simple temporal prediates>> can also be evaluated using the <<basic-cql2_comparison-predicates,standard comparison operators>>.
+NOTE: <<per_basic-cql2_time-instant-comparison,Simple temporal prediates>> involving time instants can also be evaluated using the <<basic-cql2_comparison-predicates,standard comparison operators>>.
 
 The following table specifies the definition of the temporal operators where both operands may be instants or intervals, including mixed combinations.
 

--- a/extensions/cql/standard/schema/cql2.json
+++ b/extensions/cql/standard/schema/cql2.json
@@ -132,13 +132,22 @@
             "between": {
                "type": "array",
                "items": [
-                  { "$ref": "#/$defs/valueExpression" },
-                  { "$ref": "#/$defs/scalarExpression" },
-                  { "$ref": "#/$defs/scalarExpression" }
+                  { "$ref": "#/$defs/numericExpression" },
+                  { "$ref": "#/$defs/numericExpression" },
+                  { "$ref": "#/$defs/numericExpression" }
                ],
                "additionalItems": false
             }
          }
+      },
+
+      "numericExpression": {
+         "oneOf": [
+            {"type": "number"},
+            {"$ref": "#/$defs/propertyRef"},
+            {"$ref": "#/$defs/functionRef"},
+            {"$ref": "#/$defs/arithmeticExpression"}
+         ]
       },
 
       "isLikePredicate": {
@@ -670,6 +679,7 @@
             { "type": "string" },
             { "type": "number" },
             { "type": "boolean"},
+            { "$ref": "#/$defs/instantLiteral" },
             {
               "type": "object",
               "required": [ "upper" ],


### PR DESCRIPTION
Patch a bug in the CQL2 JSON Schema that did not allow simple temporal predicates to be evaluated using the standard comparison operators.  Also, add clarifying text in the Temporal Operators clause indicating that the standard comparison operators can be used to evaluate simple temporal predicates.

Also patched a bug in the BETWEEN operator so that it matches the definition in the BNF.