### PR TITLE
issue-557: consistent handling of NULL in predicate evaluation in the requirements

### DIFF
--- a/extensions/cql/standard/clause_8_basic_cql2.adoc
+++ b/extensions/cql/standard/clause_8_basic_cql2.adoc
@@ -33,6 +33,8 @@ A collection item that satisfies ALL the requirements of a CQL2 filter expressio
 evaluates to a Boolean value of `TRUE`; otherwise the CQL2 filter expression
 evaluates to `FALSE`.
 
+NOTE: The requirements in the rest of this specification only discuss predicates as evaluating to `TRUE` or `FALSE` and don't explicitly discuss predicates that evaluate to `NULL`.  This is because, for the purpose of evaluating a CQL2 filter expression, a query prediate that evaluates to `NULL` (i.e. of unknown value) is essentually the same as one that evaluates to `FALSE`.  That is, its effect is that a collection item being evaluated by the CQL2 filter expression would _not_ be passed on for further evaluation.
+
 include::requirements/basic-cql2/REQ_cql2-filter.adoc[]
 
 Literal values do not have to be supported on the left hand side of predicates and 

--- a/extensions/cql/standard/clause_8_basic_cql2.adoc
+++ b/extensions/cql/standard/clause_8_basic_cql2.adoc
@@ -33,7 +33,7 @@ A collection item that satisfies ALL the requirements of a CQL2 filter expressio
 evaluates to a Boolean value of `TRUE`; otherwise the CQL2 filter expression
 evaluates to `FALSE`.
 
-NOTE: The requirements in the rest of this specification only discuss predicates as evaluating to `TRUE` or `FALSE` and don't explicitly discuss predicates that evaluate to `NULL`.  This is because, for the purpose of evaluating a CQL2 filter expression, a query prediate that evaluates to `NULL` (i.e. of unknown value) is essentually the same as one that evaluates to `FALSE`.  That is, its effect is that a collection item being evaluated by the CQL2 filter expression would _not_ be passed on for further evaluation.
+NOTE: The requirements in the rest of this specification only discuss predicates as evaluating to `TRUE` or `FALSE` and don't explicitly discuss predicates that evaluate to `NULL`.  For the purpose of evaluating a CQL2 filter expression, a query prediate that evaluates to `NULL` (i.e. of unknown value) is essentually the same as one that evaluates to `FALSE`.  That is, its effect is that a collection item being evaluated by the CQL2 filter expression would _not_ be passed on for further evaluation.
 
 include::requirements/basic-cql2/REQ_cql2-filter.adoc[]
 

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example04.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example04.json
@@ -1,3 +1,3 @@
 ["all", ["<", ["get", "ro:cloud_cover"], 0.1], 
-        ["=", ["get", "landsat:wrs_row"], 28],
-        ["=", ["get", "landsat:wrs_path"], 203]]
+        ["==", ["get", "landsat:wrs_row"], 28],
+        ["==", ["get", "landsat:wrs_path"], 203]]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example05a.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example05a.json
@@ -1,2 +1,2 @@
-["any", ["=", ["get", "ro:cloud_cover"], 0.1],
-        ["=", ["get", "ro:cloud_cover"], 0.2]]
+["any", ["==", ["get", "ro:cloud_cover"], 0.1],
+        ["==", ["get", "ro:cloud_cover"], 0.2]]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example06a.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example06a.json
@@ -1,3 +1,3 @@
 ["all", ["between", ["get", "eo:cloud_cover"], 0.1, 0.2],
-        ["=", ["get", "landsat:wrs_row"], 28],
-        ["=", ["get", "landsat:wrs_path"], 203] ]
+        ["==", ["get", "landsat:wrs_row"], 28],
+        ["==", ["get", "landsat:wrs_path"], 203] ]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example06b.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example06b.json
@@ -1,4 +1,4 @@
 ["all", [">=", ["get", "eo,cloud_cover"], 0.1],
         ["<=", ["get", "eo,cloud_cover"], 0.2],
-        ["=", ["get", "landsat,wrs_row"], 28],
-        ["=", ["get", "landsat,wrs_path"], 203]]
+        ["==", ["get", "landsat,wrs_row"], 28],
+        ["==", ["get", "landsat,wrs_path"], 203]]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example08.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example08.json
@@ -1,7 +1,7 @@
 ["any",
-  ["=", ["get", "beamMode"], "ScanSAR Narrow"],
-  ["=", ["get", "swathDirection"], "ascending"],
-  ["=", ["get", "polarization"], "HH+VV+HV+VH"],
+  ["==", ["get", "beamMode"], "ScanSAR Narrow"],
+  ["==", ["get", "swathDirection"], "ascending"],
+  ["==", ["get", "polarization"], "HH+VV+HV+VH"],
   ["s_intersects", ["get", "footprint"],
                    {"type": "Polygon", "coordinates": [[
                    [-77.117938,38.936860], [-77.040604,39.995648],

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example14.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example14.json
@@ -1,1 +1,1 @@
-["=", ["get", "swimming_pool"], true]
+["==", ["get", "swimming_pool"], true]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example15.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example15.json
@@ -1,2 +1,2 @@
 ["all", [">", ["get", "floor"], 5],
-        ["=", ["get", "swimming_pool"], true]]
+        ["==", ["get", "swimming_pool"], true]]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example16.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example16.json
@@ -1,4 +1,4 @@
-["and", ["=", ["get", "swimming_pool"], true],
+["and", ["==", ["get", "swimming_pool"], true],
         ["any", [">", ["get", "floor"], 5],
                 ["like", ["get", "material"], "brick%"],
                 ["like", [ "get", "material"],  "%brick"]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example17.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example17.json
@@ -1,5 +1,5 @@
 ["any", ["all", [">", ["get", "floors"], 5],
-                ["=", ["get", "material"], "brick"]
+                ["==", ["get", "material"], "brick"]
         ],
-        ["=", ["get", "swimming_pool"], true]
+        ["==", ["get", "swimming_pool"], true]
 ]

--- a/extensions/cql/standard/schema/examples/alt-json-encoding/example18.json
+++ b/extensions/cql/standard/schema/examples/alt-json-encoding/example18.json
@@ -1,3 +1,3 @@
 ["any", ["!", ["<", ["get", "floors"], 5]],
-        ["=", ["get", "swimming_pool"], true]
+        ["==", ["get", "swimming_pool"], true]
 ]


### PR DESCRIPTION
Add a NOTE indicating that a predicate that evaluates to NULL is the same as a predicate that evaluates to FALSE.  We do this so that we do not, in each requirement, have to deal with the case where the predicate evaluates to NULL.