### PR TITLE
review requirements class dependencies

### DIFF
--- a/cql2/standard/annex_bibliography.adoc
+++ b/cql2/standard/annex_bibliography.adoc
@@ -8,3 +8,4 @@
 * [[iso8601-1]] ISO 8601-1:2019, **Date and time — Representations for information interchange — Part 1: Basic rules**
 * [[iso8601-2]] ISO 8601-2:2019, **Date and time — Representations for information interchange — Part 2: Extensions**
 * [[iso15836-2]] ISO 15836-2:2019, **Information and documentation — The Dublin Core metadata element set — Part 2: DCMI Properties and classes**
+* [[OGCFeat-3]] Open Geospatial Consortium (OGC). **OGC API - Features - Part 3: Filtering (Draft)** [online]. Edited by P. Vretanos, C. Portele. To be published. Available at https://docs.ogc.org/DRAFTS/19-079r1.html

--- a/cql2/standard/clause_2_conformance.adoc
+++ b/cql2/standard/clause_2_conformance.adoc
@@ -38,10 +38,10 @@ The specific set of operators defined in this requirements class is:
 ** greater than or equal to
 ** is null
 
-Basic CQL2 only requires support for property-literal comparisons. That means that servers only has to support property references as expressions on the left hand side of an operator, and only literal values as expressions on the right hand side.
+Basic CQL2 only requires support for property-literal comparisons. That means that servers only have to support property references as expressions on the left hand side of an operator, and only literal values as expressions on the right hand side.
 
 An encoding of CQL2 may be used as the value of the filter parameters defined
-in the <<rc_filter,Filter>> requirements class.
+in the "Filter" requirements class specified in <<OGCFeat-3,OGC API - Features - Part 3: Filtering>>.
 
 The <<rc_advanced-comparison-operators,Advanced Comparison Operators>> requirements class specifies additional comparison operators:
 
@@ -110,8 +110,8 @@ latexmath:[+, -, *, /] in a CQL2 expression.
 
 The <<rc_cql2-text,CQL2 Text encoding>> requirements class defines
 a text encoding for CQL2. Such an encoding is suitable for use with HTTP query
-parameters such as the `filter` parameter defined by the <<rc_filter,Filter>>
-requirements class.
+parameters such as the `filter` parameter defined by the "Filter" requirements class specified 
+in <<OGCFeat-3,OGC API - Features - Part 3: Filtering>>.
 
 The <<rc_cql2-json,CQL2 JSON encoding>> requirements class defines
 a JSON encoding for CQL2. Such as encoding is suitable for use as the

--- a/cql2/standard/clause_4_terms_and_definitions.adoc
+++ b/cql2/standard/clause_4_terms_and_definitions.adoc
@@ -9,7 +9,7 @@ For the purposes of this document, the following additional terms and definition
 
 [[collection-def]]
 ==== collection
-a body of resources that belong or are used together; an aggregate, set, or group of related resources (http://docs.opengeospatial.org/DRAFTS/20-024.html#terms_and_definitions[OGC 20-024, OGC API - Common - Part 2: Collections]).
+a body of **resources** that belong or are used together; an aggregate, set, or group of related **resources** (http://docs.opengeospatial.org/DRAFTS/20-024.html#terms_and_definitions[OGC 20-024, OGC API - Common - Part 2: Collections]).
 
 [[filter-def]]
 ==== filter expression

--- a/cql2/standard/clause_6_basic_cql2.adoc
+++ b/cql2/standard/clause_6_basic_cql2.adoc
@@ -50,7 +50,8 @@ Support for the parts of CQL2 that are not part of Basic CQL2 is added in additi
 requirements classes in <<cql2-enhancements>>:
 
 * The rules `isLikePredicate`, `isBetweenPredicate` and `isInListPredicate` are added by requirements class <<rc_advanced-comparison-operators,Advanced Comparison Operators>>;
-* The rule `spatialPredicate` is added by requirements class <<rc_spatial-operators,Spatial Operators>>;
+* #TODO: add Case-insensitive Comparison#
+* The rule `spatialPredicate` is added by requirements classes <<rc_basic-spatial-operators,Basic Spatial Operators>> and <<rc_spatial-operators,Spatial Operators>>;
 * The rule `temporalPredicate` is added by requirements class <<rc_temporal-operators,Temporal Operators>>.
 * The rule `arrayPredicate` is added by requirements class <<rc_array-operators,Array Operators>>;
 * The permission to not support the literal rules on the left hand side of predicates and the rule `propertyName` on the right hand side are removed by requirements class <<rc_property-property,Property-Property Comparisons>>;
@@ -93,7 +94,7 @@ false
 ----
 POLYGON((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.6390, 43.5845 -79.5442))
 ----
-* spatial geometry (JSON)
+* spatial geometry (GeoJSON)
 [source,JSON]
 ----
 {

--- a/cql2/standard/clause_7_enhanced.adoc
+++ b/cql2/standard/clause_7_enhanced.adoc
@@ -127,7 +127,7 @@ include::requirements/basic-spatial-operators/REQ_spatial-operators.adoc[]
 
 include::recommendations/basic-spatial-operators/PER_spatial-predicates.adoc[]
 
-CQL2 uses Well-Known Text (WKT) to encode geometry literals. Since WKT does not provide a capability to specify the CRS of a geometry literal, the server has to determine the CRS of the geometry literals in a filter expression through another mechanism. In this standard, the `filter-crs` query parameter is used to pass the CRS information to the server.
+CQL2 uses Well-Known Text (WKT) or GeoJSON to encode geometry literals. Since WKT and GeoJSON do not provide a capability to specify the CRS of a geometry literal, the server has to determine the CRS of the geometry literals in a filter expression through another mechanism. For example, a query parameter `filter-crs` is used in <<OGCFeat-3,OGC API - Features - Part 3: Filtering>> to pass the CRS information to the server.
 
 [[example_9_1]]
 .Example spatial predicate

--- a/cql2/standard/clause_8_encodings.adoc
+++ b/cql2/standard/clause_8_encodings.adoc
@@ -12,7 +12,8 @@ include::requirements/requirements_class_cql2-text.adoc[]
 
 This requirements class defines a Well Known Text (WKT) encoding of CQL2. Such an
 encoding would be suitable for use with the GET query parameter such as the
-<<rc_filter,`filter`>> parameter.
+`filter` query parameter specified by the "Filter" requirements class
+in <<OGCFeat-3,OGC API - Features - Part 3: Filtering>>.
 
 The "CQL2 Text" encoding is defined by the BNF grammar defined in <<cql2-bnf>>.
 
@@ -67,8 +68,6 @@ The list of CQL2 keywords includes:
 * "T_STARTS"
 * "TRUE"
 
-include::requirements/cql2-text/REQ_filter-lang.adoc[]
-
 include::requirements/cql2-text/REQ_basic-cql2.adoc[]
 
 include::requirements/cql2-text/REQ_basic-spatial-operators.adoc[]
@@ -94,8 +93,6 @@ This requirements class defines a JSON encoding of CQL2. Such an encoding
 would be suitable as the body of an HTTP POST request.
 
 NOTE: Attention is drawn to the fact that there exists an alternative JSON encoding for CQL2 based on the use of arrays that can be found here: https://github.com/tschaub/ogcapi-features/tree/json-array-expression/extensions/cql/jfe. The OGC API - Features Standards Working Group will review both encodings and decide which one to adopt. Feedback from implementers is welcome.
-
-include::requirements/cql2-json/REQ_filter-lang.adoc[]
 
 include::requirements/cql2-json/REQ_basic-cql2.adoc[]
 

--- a/cql2/standard/recommendations/advanced-comparison-operators/PER_like-predicate.adoc
+++ b/cql2/standard/recommendations/advanced-comparison-operators/PER_like-predicate.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/advanced-comparison-operators/like-predicate*
-^|A |The server MAY not support `characterLiteral` as the scalar expression (rule `scalarExpression`) in rule `isLikePredicate`.
+^|A |The server MAY not support `characterLiteral` as the character expression (rule `characterExpression`) in rule `isLikePredicate`.
 |===

--- a/cql2/standard/recommendations/basic-cql2/PER_time-instant-comparisons.adoc
+++ b/cql2/standard/recommendations/basic-cql2/PER_time-instant-comparisons.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/basic-cql2/time-instant-comparison* +
-2+|In lieu of using the formal <<temporal-operators,temporal operators>>, binary comparison operators may be used evaluate simple temporal predicates (rule: `binaryComparisonPredicate`) involving time instants (rule: `instantLiteral`).
+2+|In lieu of using the formal <<temporal-operators,temporal operators>>, binary comparison operators may be used to evaluate simple temporal predicates (rule: `binaryComparisonPredicate`) involving time instants (rule: `instantLiteral`).
 |===

--- a/cql2/standard/requirements/advanced-comparison-operators/REQ_like-predicate.adoc
+++ b/cql2/standard/requirements/advanced-comparison-operators/REQ_like-predicate.adoc
@@ -3,7 +3,7 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/advanced-comparison-operators/like-predicate*
 ^|A |The _like predicate_ (rule `isLikePredicate`) tests whether a string value matches the specified pattern. If the value matches the pattern (rule `patternExpression`), then the predicate SHALL evaluate to the Boolean value `TRUE`. Otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
-^|B |The scalar expression (rule `scalarExpression`) in rule `isLikePredicate` SHALL evaluate to a `characterLiteral`.
+^|B |The character expression (rule `characterExpression`) in rule `isLikePredicate` SHALL evaluate to a `characterLiteral`.
 ^|C |The wildcard character SHALL be the percent character (ASCII x25, `%`).
 ^|D |The wildcard SHALL match zero of more characters in the test value.
 ^|E |The wildcard character SHALL not match the NULL value.

--- a/cql2/standard/requirements/array-operators/REQ_array-predicates.adoc
+++ b/cql2/standard/requirements/array-operators/REQ_array-predicates.adoc
@@ -14,7 +14,7 @@ with the exception of the following rules:
 SHALL evaluate to the Boolean value `FALSE`.
 * `A_CONTAINS` evaluates to the Boolean value `TRUE`, if the first set is a superset of the second set; 
 otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
-* `A_CONTAINED BY` evaluates to the Boolean value `TRUE`, if the first set is a subset of the second set; 
+* `A_CONTAINEDBY` evaluates to the Boolean value `TRUE`, if the first set is a subset of the second set; 
 otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
 * `A_OVERLAPS` evaluates to the Boolean value `TRUE`, if both sets share at least one common element; 
 otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.

--- a/cql2/standard/requirements/basic-cql2/REQ_cql2-filter.adoc
+++ b/cql2/standard/requirements/basic-cql2/REQ_cql2-filter.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/basic-cql2/cql2filter* 
-^|A |A server SHALL support a CQL2 filter expression composed of a logically connected series of one or more predicates as described by the BNF rule `booleanValueExpression` in <<cql2-bnf>> exception that the rules `isLikePredicate`, `isBetweenPredicate`, `isInListPredicate`, `spatialPredicate`, `temporalPredicate`, `arrayPredicate`, `function` and `arithmeticExpression` do not have to be supported.
+^|A |A server SHALL support a CQL2 filter expression composed of a logically connected series of one or more predicates as described by the BNF rule `booleanValueExpression` in <<cql2-bnf>> with the exception that the rules `isLikePredicate`, `isBetweenPredicate`, `isInListPredicate`, `spatialPredicate`, `temporalPredicate`, `arrayPredicate`, `function` and `arithmeticExpression` do not have to be supported.
 |===
 

--- a/cql2/standard/requirements/cql2-json/REQ_filter-lang.adoc
+++ b/cql2/standard/requirements/cql2-json/REQ_filter-lang.adoc
@@ -1,7 +1,0 @@
-[[req_cql2-json_filter-lang]]
-[width="90%",cols="2,6a"]
-|===
-^|*Requirement {counter:req-id}* |*/req/cql2-json/filter-lang*
-^|Condition |Server implements requirements class <<rc_filter,Filter>>
-^|A |If a filter expression is encoded as JSON, this SHALL be indicated using the value `cql2-json` as the value of the <<filter-lang-param,filter-lang>> parameter.
-|===

--- a/cql2/standard/requirements/cql2-text/REQ_filter-lang.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_filter-lang.adoc
@@ -1,7 +1,0 @@
-[[req_cql2-text_filter-lang]]
-[width="90%",cols="2,6a"]
-|===
-^|*Requirement {counter:req-id}* |*/req/cql2-text/filter-lang*
-^|Condition |Server implements requirements class <<rc_filter,Filter>>
-^|A |If a filter expression is encoded as text, this SHALL be indicated using the value `cql2-text` as the value of the <<filter-lang-param,filter-lang>> parameter.
-|===

--- a/cql2/standard/requirements/requirements_class_cql2-json.adoc
+++ b/cql2/standard/requirements/requirements_class_cql2-json.adoc
@@ -11,5 +11,4 @@
 |Conditional Dependency |<<rc_array-operators,Requirements Class "Array Operators">>
 |Conditional Dependency |<<rc_functions,Requirements Class "Custom Functions">>
 |Conditional Dependency |<<rc_arithmetic,Requirements Class "Arithmetic Expressions">>
-|Conditional Dependency |<<rc_filter,Requirements Class "Filter">>
 |===

--- a/cql2/standard/requirements/requirements_class_cql2-text.adoc
+++ b/cql2/standard/requirements/requirements_class_cql2-text.adoc
@@ -11,5 +11,4 @@
 |Conditional Dependency |<<rc_array-operators,Requirements Class "Array Operators">>
 |Conditional Dependency |<<rc_functions,Requirements Class "Custom Functions">>
 |Conditional Dependency |<<rc_arithmetic,Requirements Class "Arithmetic Expressions">>
-|Conditional Dependency |<<rc_filter,Requirements Class "Filter">>
 |===

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -4,10 +4,11 @@
 # HISTORY:
 # DATE         EMAIL                                  DESCRIPTION
 # 13-SEP-2019  pvretano[at]cubewerx.com               Initial creation
-# 28-OCT-2019  pvretano[at]cubewerx.com               Initial checkin into github
-# 22-NOV-2020  pvretano[at]cubewerx.com               Updates based on issues
-# 22-NOV-2020  portele[at]interactive-instruments.de  Document restructuring
-# 21-DEC-2020  pvretano[at]cubewerx.com               Updates to resolve issues
+# 28-OCT-2019  pvretano[at]cubewerx.com               Initial check-in into github
+# 22-DEC-2020  pvretano[at]cubewerx.com               1.0.0-draft.1 (version for public review)
+#              portele[at]interactive-instruments.de  
+# xx-xxx-202x  pvretano[at]cubewerx.com               1.0.0-draft.x (release candidate)
+#              portele[at]interactive-instruments.de  
 
 #=============================================================================#
 # A CQL2 filter is a logically connected expression of one or more predicates.
@@ -67,7 +68,12 @@ lteq = lt eq;
 
 # LIKE predicate
 #
-isLikePredicate =  scalarExpression "LIKE" patternExpression;
+isLikePredicate =  characterExpression "LIKE" patternExpression;
+
+characterExpression = characterLiteral
+                    | propertyName
+                    | function
+                    | arithmeticExpression;
 
 patternExpression = characterLiteral;
 

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -72,8 +72,7 @@ isLikePredicate =  characterExpression "LIKE" patternExpression;
 
 characterExpression = characterLiteral
                     | propertyName
-                    | function
-                    | arithmeticExpression;
+                    | function;
 
 patternExpression = characterLiteral;
 

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -85,11 +85,7 @@ numericExpression = numericLiteral
 #
 isInListPredicate = inListOperand ["NOT"] "IN" leftParen inList rightParen;
 
-inList = inListOperand [ {comma inListOperand} ];
-
-inListOperand = scalarExpression
-              | intervalLiteral
-              | spatialLiteral;
+inList = scalarExpression [ {comma scalarExpression} ];
 
 # IS NULL predicate
 #

--- a/cql2/standard/schema/cql2.json
+++ b/cql2/standard/schema/cql2.json
@@ -158,13 +158,22 @@
                "type": "array",
                "items": {
                   "oneOf": [
-                     { "$ref": "#/$defs/scalarExpression" },
+                     { "$ref": "#/$defs/characterExpression" },
                      { "type": "string" }
                   ]
                },
                "additionalItems": false
             }
          }
+      },
+
+      "characterExpression": {
+         "oneOf": [
+            {"type": "string"},
+            {"$ref": "#/$defs/propertyRef"},
+            {"$ref": "#/$defs/functionRef"},
+            {"$ref": "#/$defs/arithmeticExpression"}
+         ]
       },
 
       "isInListPredicate": {

--- a/cql2/standard/schema/cql2.json
+++ b/cql2/standard/schema/cql2.json
@@ -175,11 +175,11 @@
                "type": "array",
                "items": {
                   "oneOf": [
-                     { "$ref": "#/$defs/valueExpression" },
+                     { "$ref": "#/$defs/scalarExpression" },
                      {
                         "type": "array",
                         "items": {
-                           "$ref": "#/$defs/valueExpression"
+                           "$ref": "#/$defs/scalarExpression"
                         }
                      }
                   ]
@@ -187,14 +187,6 @@
                "additionalItems": false
             }
          }
-      },
-
-      "valueExpression": {
-         "oneOf": [
-            {"$ref": "#/$defs/scalarExpression"},
-            {"$ref": "#/$defs/spatialLiteral"},
-            {"$ref": "#/$defs/intervalLiteral"}
-         ]
       },
 
       "scalarOperands": {

--- a/cql2/standard/schema/cql2.json
+++ b/cql2/standard/schema/cql2.json
@@ -171,8 +171,7 @@
          "oneOf": [
             {"type": "string"},
             {"$ref": "#/$defs/propertyRef"},
-            {"$ref": "#/$defs/functionRef"},
-            {"$ref": "#/$defs/arithmeticExpression"}
+            {"$ref": "#/$defs/functionRef"}
          ]
       },
 

--- a/cql2/standard/schema/cql2.yml
+++ b/cql2/standard/schema/cql2.yml
@@ -139,7 +139,6 @@ components:
         - type: string
         - $ref: '#/components/schemas/propertyRef'
         - $ref: '#/components/schemas/functionRef'
-        - $ref: '#/components/schemas/arithmeticExpression'
     isInListPredicate:
       type: object
       required:

--- a/cql2/standard/schema/cql2.yml
+++ b/cql2/standard/schema/cql2.yml
@@ -143,16 +143,11 @@ components:
         in:
           type: array
           items:
-            - $ref: '#/components/schemas/valueExpression'
+            - $ref: '#/components/schemas/scalarExpression'
             - type: array
               items:
-                $ref: '#/components/schemas/valueExpression'
+                $ref: '#/components/schemas/scalarExpression'
           additionalItems: false
-    valueExpression:
-      oneOf:
-        - $ref: '#/components/schemas/scalarExpression'
-        - $ref: '#/components/schemas/spatialLiteral'
-        - $ref: '#/components/schemas/intervalLiteral'
     scalarOperands:
       type: array
       minItems: 2

--- a/cql2/standard/schema/cql2.yml
+++ b/cql2/standard/schema/cql2.yml
@@ -17,7 +17,6 @@ components:
         - $ref: '#/components/schemas/spatialPredicate'
         - $ref: '#/components/schemas/temporalPredicate'
         - $ref: '#/components/schemas/arrayPredicate'
-      $recursiveAnchor: true
     andExpression:
       type: object
       required:
@@ -27,7 +26,7 @@ components:
           type: array
           minItems: 2
           items:
-            $recursiveRef: '#'
+            $ref: '#/components/schemas/booleanValueExpression'
     orExpression:
       type: object
       required:
@@ -37,7 +36,7 @@ components:
           type: array
           minItems: 2
           items:
-            $recursiveRef: '#'
+            $ref: '#/components/schemas/booleanValueExpression'
     notExpression:
       type: object
       required:
@@ -48,7 +47,7 @@ components:
           minItems: 1
           maxItems: 1
           items:
-            $recursiveRef: '#'
+            $ref: '#/components/schemas/booleanValueExpression'
     comparisonPredicate:
       oneOf:
         - $ref: '#/components/schemas/binaryComparisonPredicate'
@@ -113,11 +112,10 @@ components:
       properties:
         between:
           type: array
+          minItems: 3
+          maxItems: 3
           items:
-            - $ref: '#/components/schemas/numericExpression'
-            - $ref: '#/components/schemas/numericExpression'
-            - $ref: '#/components/schemas/numericExpression'
-          additionalItems: false
+            $ref: '#/components/schemas/numericExpression'
     numericExpression:
       oneOf:
         - type: number
@@ -131,10 +129,17 @@ components:
       properties:
         like:
           type: array
+          minItems: 2
+          maxItems: 2
           items:
-            - $ref: '#/components/schemas/scalarExpression'
-            - type: string
-          additionalItems: false
+            # the second item is always a characterLiteral
+            $ref: '#/components/schemas/characterExpression'
+    characterExpression:
+      oneOf:
+        - type: string
+        - $ref: '#/components/schemas/propertyRef'
+        - $ref: '#/components/schemas/functionRef'
+        - $ref: '#/components/schemas/arithmeticExpression'
     isInListPredicate:
       type: object
       required:
@@ -143,11 +148,12 @@ components:
         in:
           type: array
           items:
-            - $ref: '#/components/schemas/scalarExpression'
-            - type: array
-              items:
-                $ref: '#/components/schemas/scalarExpression'
-          additionalItems: false
+            # the first item is always a scalarExpression, the second an array
+            oneOf:
+              - $ref: '#/components/schemas/scalarExpression'
+              - type: array
+                items:
+                  $ref: '#/components/schemas/scalarExpression'
     scalarOperands:
       type: array
       minItems: 2


### PR DESCRIPTION
* remove interval/spatial geometry from IN
* add OGC API Features Part 3 to bibliography
* correct references to "filter" requirements class
* remove normative references to OGC API Features Part 3
* update LIKE operator to remove support for numeric/boolean/instant literals
* remove constructs from cql2.yml that are not supported by the OpenAPI 3.0 schema object
* some editorial improvements

closes #638
