### PR TITLE
interval types / terminology

### DIFF
--- a/core/openapi/ogcapi-features-1.yaml
+++ b/core/openapi/ogcapi-features-1.yaml
@@ -73,14 +73,14 @@ components:
       name: datetime
       in: query
       description: |-
-        Either a date-time or an interval, open or closed. Date and time expressions
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
+        Either a date-time or an interval. Date and time expressions adhere to RFC 3339. 
+        Intervals may be bounded or half-bounded (double-dots at start or end).
 
         Examples:
 
         * A date-time: "2018-02-12T23:20:50Z"
-        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+        * A bounded interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+        * Half-bounded intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
 
         Only features that have a temporal property that intersects the value of
         `datetime` are selected.
@@ -277,7 +277,7 @@ components:
             interval:
               description: |-
                 One or more time intervals that describe the temporal extent of the dataset.
-                The value `null` is supported and indicates an open time interval.
+                The value `null` is supported and indicates an unbounded interval end.
                 In the Core only a single time interval is supported. Extensions may support
                 multiple intervals. If multiple intervals are provided, the union of the
                 intervals describes the temporal extent.

--- a/core/openapi/parameters/datetime.yaml
+++ b/core/openapi/parameters/datetime.yaml
@@ -1,14 +1,14 @@
 name: datetime
 in: query
 description: |-
-  Either a date-time or an interval, open or closed. Date and time expressions
-  adhere to RFC 3339. Open intervals are expressed using double-dots.
+  Either a date-time or an interval. Date and time expressions adhere to RFC 3339. 
+  Intervals may be bounded or half-bounded (double-dots at start or end).
 
   Examples:
 
   * A date-time: "2018-02-12T23:20:50Z"
-  * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-  * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+  * A bounded interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+  * Half-bounded intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
 
   Only features that have a temporal property that intersects the value of
   `datetime` are selected.

--- a/core/openapi/schemas/extent.yaml
+++ b/core/openapi/schemas/extent.yaml
@@ -3,11 +3,10 @@ description: |-
   extents are specified. Extensions may add additional members to represent other
   extents, for example, thermal or pressure ranges.
 
-  The first item in the array describes the overall extent of
-  the data. All subsequent items describe more precise extents, 
-  e.g., to identify clusters of data.
-  Clients only interested in the overall extent will only need to
-  access the first item in each array.
+  An array of extents is provided for each extent type (spatial, temporal). The first item 
+  in the array describes the overall extent of the data. All subsequent items describe more 
+  precise extents, e.g., to identify clusters of data. Clients only interested in the 
+  overall extent will only need to access the first extent in the array.
 type: object
 properties:
   spatial:
@@ -25,7 +24,7 @@ properties:
           extent of the data. All subsequent bounding boxes describe 
           more precise bounding boxes, e.g., to identify clusters of data.
           Clients only interested in the overall spatial extent will
-          only need to access the first item in each array.
+          only need to access the first bounding box in the array.
         type: array
         minItems: 1
         items:
@@ -100,8 +99,9 @@ properties:
           The first time interval describes the overall
           temporal extent of the data. All subsequent time intervals describe 
           more precise time intervals, e.g., to identify clusters of data.
-          Clients only interested in the overall extent will only need
-          to access the first item in each array.
+          Clients only interested in the overall temporal extent will only need
+          to access the first time interval in the array (a pair of lower and upper 
+          bound instants).
         type: array
         minItems: 1
         items:

--- a/core/openapi/schemas/extent.yaml
+++ b/core/openapi/schemas/extent.yaml
@@ -110,7 +110,7 @@ properties:
             temporal coordinate reference system specified in `trs`. By default
             this is the Gregorian calendar.
             
-            The value `null` is supported and indicates an open time interval.
+            The value `null` at start or end is supported and indicates a half-bounded interval.
           type: array
           minItems: 2
           maxItems: 2

--- a/core/standard/abstract_tests/core/ATS_fc-md-extent.adoc
+++ b/core/standard/abstract_tests/core/ATS_fc-md-extent.adoc
@@ -5,5 +5,5 @@
 ^|Test Purpose |Validate the `extent` property, if it is present
 ^|Requirement |<<req_core_fc-md-extent,/req/core/fc-md-extent>>
 ^|Test Method |. Verify that the `extent`, if present, provides bounding boxes that include all spatial geometries in this collection.
-. Verify that the `extent`, if present, provides time intervals that include all temporal geometries in this collection. A temporal boundary of `null` indicates an open time interval.
+. Verify that the `extent`, if present, provides time intervals that include all temporal geometries in this collection. A temporal boundary of `null` at start or end indicates a half-bounded interval.
 |===

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -743,7 +743,7 @@ include::requirements/core/REQ_fc-time-response.adoc[]
 
 "Intersects" means that the time (instant or interval) specified in the parameter `datetime` includes a timestamp that is part of the temporal geometry of the feature (again, a time instant or interval). For time intervals this includes the start and end time.
 
-NOTE: The interval notation is taken from <<iso8601-2,ISO 8601-2:2019>>. ISO 8601-2 distinguishes open start/end timestamps (double-dot) and unknown start/end timestamps (empty string). For queries, an unknown start/end has the same effect as an unbounded start/end.
+NOTE: The interval notation is taken from <<iso8601-2,ISO 8601-2:2019>>. ISO 8601-2 distinguishes between bounded start/end timestamps (double-dot) and unknown start/end timestamps (empty string). For queries, an unknown start/end has the same effect as an unbounded start/end.
 
 [[example_6]]
 .A date-time

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -558,7 +558,7 @@ properties:
           interval:
             description: >-
               One or more time intervals that describe the temporal extent of the dataset.
-              The value `null` is supported and indicates an open time interval.
+              The value `null` is supported and indicates an unbounded interval end.
               In the Core only a single time interval is supported. Extensions may support
               multiple intervals. If multiple intervals are provided, the union of the
               intervals describes the temporal extent.
@@ -743,7 +743,7 @@ include::requirements/core/REQ_fc-time-response.adoc[]
 
 "Intersects" means that the time (instant or interval) specified in the parameter `datetime` includes a timestamp that is part of the temporal geometry of the feature (again, a time instant or interval). For time intervals this includes the start and end time.
 
-NOTE: The interval notation is taken from <<iso8601-2,ISO 8601-2:2019>>. ISO 8601-2 distinguishes open start/end timestamps (double-dot) and unknown start/end timestamps (empty string). For queries, an unknown start/end has the same effect as an open start/end.
+NOTE: The interval notation is taken from <<iso8601-2,ISO 8601-2:2019>>. ISO 8601-2 distinguishes open start/end timestamps (double-dot) and unknown start/end timestamps (empty string). For queries, an unknown start/end has the same effect as an unbounded start/end.
 
 [[example_6]]
 .A date-time

--- a/core/standard/requirements/core/REQ_fc-md-extent.adoc
+++ b/core/standard/requirements/core/REQ_fc-md-extent.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/fc-md-extent* 
-^|A |For each feature collection, the `extent` property, if provided, SHALL provide bounding boxes that include all spatial geometries and time intervals that include all temporal geometries in this collection. The temporal extent may use `null` values to indicate an open time interval.
+^|A |For each feature collection, the `extent` property, if provided, SHALL provide bounding boxes that include all spatial geometries and time intervals that include all temporal geometries in this collection. The temporal extent with a `null` value at start or end indicates a half-bounded interval.
 ^|B |If a feature has multiple properties with spatial or temporal information, it is the decision of the server whether only a single spatial or temporal geometry property is used to determine the extent or all relevant geometries.
 |===

--- a/core/standard/requirements/core/REQ_fc-time-response.adoc
+++ b/core/standard/requirements/core/REQ_fc-time-response.adoc
@@ -8,12 +8,12 @@
 ^|D |Temporal geometries are either a date-time value or a time interval. The parameter value SHALL conform to the following syntax (using link:https://tools.ietf.org/html/rfc2234[ABNF]):
 
 ```
-interval-closed     = date-time "/" date-time
-interval-open-start = [".."] "/" date-time
-interval-open-end   = date-time "/" [".."]
-interval            = interval-closed / interval-open-start / interval-open-end
-datetime            = date-time / interval
+interval-bounded            = date-time "/" date-time
+interval-half-bounded-start = [".."] "/" date-time
+interval-half-bounded-end   = date-time "/" [".."]
+interval                    = interval-closed / interval-half-bounded-start / interval-half-bounded-end
+datetime                    = date-time / interval
 ```
 ^|E |The syntax of `date-time` is specified by link:https://tools.ietf.org/html/rfc3339#section-5.6[RFC 3339, 5.6].
-^|F |Open ranges in time intervals at the start or end are supported using a double-dot (`..`) or an empty string for the start/end.
+^|F |Half-bounded time intervals are supported using a double-dot (`..`) or an empty string for the start/end.
 |===


### PR DESCRIPTION
See opengeospatial/ogcapi-common#196.

* Use "half-bounded interval" instead of "open interval".
* Improve wording on extents.

cc @jerstlouis 