### PR TITLE
Update implementation details for ogcapi-js

### DIFF
--- a/implementations/README.adoc
+++ b/implementations/README.adoc
@@ -164,9 +164,9 @@ The columns for each part list the conformance classes of the standard that the 
 | link:clients/ogcapi-js.md[ogcapi-js]
 | `core`, `geojson`
 | `crs`
-| -
+| `filter`, `features-filter`, `simple-cql`, `cql-json`, `cql-text`
 | https://www.ogc.org/resource/products/details/?pid=1673[Link]
-|
+| haoliang.yu [at] outlook.com
 |===
 
 ### Clients supporting GeoJSON


### PR DESCRIPTION
Starting at v0.3.0, `@ogcapi-js/features` supports Features API part 3. See https://github.com/haoliangyu/ogcapi-js/issues/15.