### PR TITLE
change inListOperand to scalarExpression in normative statements

### DIFF
--- a/cql2/standard/recommendations/advanced-comparison-operators/PER_in-predicate.adoc
+++ b/cql2/standard/recommendations/advanced-comparison-operators/PER_in-predicate.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/advanced-comparison-operators/in-predicate* 
-^|A |The server MAY not support `characterLiteral`, `numericLiteral`, `booleanLiteral` or `instantLiteral` as the value to be tested (rule `inListOperand`, i.e., the left hand side of the predicate).
+^|A |The server MAY not support `characterLiteral`, `numericLiteral`, `booleanLiteral` or `instantLiteral` as the value to be tested (rule `scalarExpression`, i.e., the left hand side of the predicate).
 ^|B |The server MAY not support `propertyName` as the items in the list of an in-list predicate (rule `inList`, i.e., the items on the right hand side of the predicate).
 |===

--- a/cql2/standard/requirements/advanced-comparison-operators/REQ_in-predicate.adoc
+++ b/cql2/standard/requirements/advanced-comparison-operators/REQ_in-predicate.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/advanced-comparison-operators/in-predicate* 
 ^|A |The _in-list predicate_ (rule `isInListPredicate`) tests, for equality, the value of a scalar expression against a list of values of the same type.  If the value on the left side of the predicate is equal to one or more of the values in the list on the right side of the predicate, the predicate SHALL evaluate to the Boolean value `TRUE`. Otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
-^|B |The items in the list of an in-list predicate (rule `inList`, i.e., the items on the right hand side of the predicate) SHALL be of the same literal type as the value being tested by the predicate (rule `inListOperand`, i.e., the left hand side of the predicate), if evaluated.
+^|B |The items in the list of an in-list predicate (rule `inList`, i.e., the items on the right hand side of the predicate) SHALL be of the same literal type as the value being tested by the predicate (rule `scalarExpression`, i.e., the left hand side of the predicate), if evaluated.
 |===


### PR DESCRIPTION
PR #659 had removed inListOperand from the BNF, but there were still two cases where the rule was referenced in normative statements