### PR TITLE
Adding missing `^` operator and comma to 7.11

### DIFF
--- a/cql2/standard/clause_7_enhanced.adoc
+++ b/cql2/standard/clause_7_enhanced.adoc
@@ -715,7 +715,7 @@ include::requirements/requirements_class_arithmetic.adoc[]
 This clause specifies requirements for supporting arithmetic expressions in CQL2.
 An arithmetic expression is an expression composed of an arithmetic operand
 (a property name, a number or a function that returns a number), an arithmetic
-operator (i.e. one of +,-,*,/) and another arithmetic operand.
+operator (i.e., one of `+`, `-`, `*`, `/`, `^`) and another arithmetic operand.
 
 include::requirements/arithmetic/REQ_arithmetic.adoc[]
 


### PR DESCRIPTION
The list of operators was missing the power (caret) operator and a comma after `i.e.`.