### PR TITLE
support '-myAtt' as an arithmetic expression

### DIFF
--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -206,7 +206,7 @@ arithmeticTerm = arithmeticTerm asterisk powerTerm
 powerTerm = arithmeticFactor caret powerTerm
           | arithmeticFactor;
 arithmeticFactor = leftParen arithmeticExpression rightParen
-                 | arithmeticOperand;
+                 | [ minusSign ] arithmeticOperand;
 arithmeticOperand = numericLiteral
                   | propertyName
                   | function;


### PR DESCRIPTION
closes #709

For discussion: I have not changed the JSON Schema, i.e. one would still have to write `{ "op": "-", "args": [ 0, { "property": "myAtt" }] }`. The alternative would be to also allow only one argument for "-", but would make the schema more complex and/or less strict in validation.