### PR TITLE
clarify comparison of instants

### DIFF
--- a/cql2/standard/clause_6_basic_cql2.adoc
+++ b/cql2/standard/clause_6_basic_cql2.adoc
@@ -182,7 +182,7 @@ avg(windSpeed)
 
 include::requirements/basic-cql2/REQ_binary-comparison-predicate.adoc[]
 
-include::recommendations/basic-cql2/PER_time-instant-comparisons.adoc[]
+Instants (timestamps and dates) are scalar data types. All implementations have to support the comparison of two timestamps or tw dates. How this is implemented is a decision of the server and will depend on the internal represenation. For example, the server could compare the RFC 3339 string representations of the two timestamps.
 
 [[example_8_3]]
 .Binary comparison predicates

--- a/cql2/standard/recommendations/basic-cql2/PER_time-instant-comparisons.adoc
+++ b/cql2/standard/recommendations/basic-cql2/PER_time-instant-comparisons.adoc
@@ -1,6 +1,0 @@
-[[per_basic-cql2_time-instant-comparison]]
-[width="90%",cols="2,6a"]
-|===
-^|*Permission {counter:per-id}* |*/per/basic-cql2/time-instant-comparison* +
-^|A |In lieu of using the formal <<temporal-operators,temporal operators>>, binary comparison operators may be used to evaluate simple temporal predicates (rule: `binaryComparisonPredicate`) involving time instants (rule: `instantLiteral`).
-|===


### PR DESCRIPTION
Permission `/per/basic-cql2/time-instant-comparison` is not a permission for the server. It is converted to informative text that clarifies that all implementations have to support comparisons of instants (i.e., clients can make use of that capability).

Closes #719