### PR TITLE
add note about future evolution to an expression language

### DIFF
--- a/cql2/standard/clause_1_scope.adoc
+++ b/cql2/standard/clause_1_scope.adoc
@@ -6,3 +6,10 @@ This document defines
 
 * A text encoding for a CQL2 filter;
 * A JSON encoding for a CQL2 filter.
+
+NOTE: The CQL2 grammar contains many language elements of a general purpose, spatio-temporal expression language.
+The focus of this version of the language are boolean-valued filter expressions. It is planned to investigate, if CQL2
+should be extended through additional functions and operators to evolve into a backward-compatible expression language
+that is not restricted to boolean-valued expressions, but support expressions that result in other values, too, including
+geometries. Such expressions can be used, for example, in a style language or to define derived properties. In this case,
+a new requirements class for boolean-valued filter expressions would be added to the Standard.

--- a/cql2/standard/clause_1_scope.adoc
+++ b/cql2/standard/clause_1_scope.adoc
@@ -10,6 +10,6 @@ This document defines
 NOTE: The CQL2 grammar contains many language elements of a general purpose, spatio-temporal expression language.
 The focus of this version of the language are boolean-valued filter expressions. It is planned to investigate, if CQL2
 should be extended through additional functions and operators to evolve into a backward-compatible expression language
-that is not restricted to boolean-valued expressions, but support expressions that result in other values, too, including
+that is not restricted to boolean-valued expressions, but supports expressions that result in other values, too, including
 geometries. Such expressions can be used, for example, in a style language or to define derived properties. In this case,
 a new requirements class for boolean-valued filter expressions would be added to the Standard.

--- a/cql2/standard/clause_1_scope.adoc
+++ b/cql2/standard/clause_1_scope.adoc
@@ -7,9 +7,5 @@ This document defines
 * A text encoding for a CQL2 filter;
 * A JSON encoding for a CQL2 filter.
 
-NOTE: The CQL2 grammar contains many language elements of a general purpose, spatio-temporal expression language.
-The focus of this version of the language are boolean-valued filter expressions. It is planned to investigate, if CQL2
-should be extended through additional functions and operators to evolve into a backward-compatible expression language
-that is not restricted to boolean-valued expressions, but supports expressions that result in other values, too, including
-geometries. Such expressions can be used, for example, in a style language or to define derived properties. In this case,
-a new requirements class for boolean-valued filter expressions would be added to the Standard.
+NOTE: The CQL2 grammar contains all the necessary language elements of a general purpose expression language, including support for spatio-temporal values.
+The focus of this version of the language are boolean-valued filter expressions. It is planned to potentially remove this restriction, while maintaining backward compatibility, allowing expressions that result in values of other data types, including geometries. Such expressions could be used, for example, in a styling language to specify parameter values, or to define derived properties. In this case, a particular use of CQL2 could specify the boolean-valued restrction separately, for example when used as a filter predicate expression, or as a styling rule selector. The usability of such an expression language, especially in the context of geometry types, would also greatly benefit from standardizing additional functions and/or operators e.g., to compute the geometry resulting from buffering or intersecting operations.


### PR DESCRIPTION
See https://github.com/opengeospatial/ogcapi-features/issues/723#issuecomment-1173929247

I have added the text as a note to the scope section since the statement is about the (future) scope of the document.

@pvretano @jerstlouis 