### PR TITLE
`IS` was missing from list of keywords

### DIFF
--- a/cql2/standard/clause_8_encodings.adoc
+++ b/cql2/standard/clause_8_encodings.adoc
@@ -36,6 +36,7 @@ The list of CQL2 keywords includes:
 * "FALSE"
 * "GEOMETRYCOLLECTION"
 * "IN"
+* "IS"
 * "LIKE"
 * "LINESTRING"
 * "MULTILINESTRING"


### PR DESCRIPTION
See somewhat related comment here: https://github.com/opengeospatial/ogcapi-features/issues/705#issuecomment-1188547120 that led me to this discovery.