### PR TITLE
Updating mappings to specification elements of Part 2

### DIFF
--- a/specification-elements/18-058r1.csv
+++ b/specification-elements/18-058r1.csv
@@ -9,7 +9,6 @@ http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-md-storageCrs-valid-val
 http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-md-crs-list-global,http://www.opengis.net/spec/ogcapi-features-2/1.0/req/crs/fc-md-crs-list-global
 http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-bbox-crs-definition,http://www.opengis.net/spec/ogcapi-features-2/1.0/req/crs/fc-bbox-crs-definition
 http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-bbox-crs-valid-value,http://www.opengis.net/spec/ogcapi-features-2/1.0/req/crs/fc-bbox-crs-valid-value
-http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-bbox-crs-valid-default-value,http://www.opengis.net/spec/ogcapi-features-2/1.0/req/crs/fc-bbox-crs-valid-defaultValue
 http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-bbox-crs-valid-default-value,http://www.opengis.net/spec/ogcapi-features-2/1.0/req/crs/fc-bbox-crs-valid-default-value
 http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-bbox-crs-action,http://www.opengis.net/spec/ogcapi-features-2/1.0/req/crs/fc-bbox-crs-action
 http://docs.ogc.org/is/18-058r1/18-058r1.html#req_crs_fc-crs-definition,http://www.opengis.net/spec/ogcapi-features-2/1.0/req/crs/fc-crs-definition


### PR DESCRIPTION
Edited because there is no "fc-bbox-crs-valid-defaultValue" in the document.

There is however a "fc-bbox-crs-valid-default-value" in the document (which already has a mapping).