### PR TITLE
Refer to all spatial, temporal and array operators as standardized functions.

### DIFF
--- a/cql2/standard/annex_ats_array-operators.adoc
+++ b/cql2/standard/annex_ats_array-operators.adoc
@@ -18,7 +18,7 @@
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_array-predicates,/req/{conf-class}/array-predicates>>
-|Test purpose: | Test the array operators
+|Test purpose: | Test the array comparison functions
 |Test method: | 
 Given:
 

--- a/cql2/standard/annex_ats_basic-spatial-operators.adoc
+++ b/cql2/standard/annex_ats_basic-spatial-operators.adoc
@@ -20,7 +20,7 @@ The term "geometry data type" is used for the following data types: Point, Multi
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-predicate,/req/{conf-class}/spatial-predicate>>, <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_INTERSECTS operator
+|Test purpose: | Test the S_INTERSECTS spatial comparison function.
 |Test method: | 
 Given:
 

--- a/cql2/standard/annex_ats_spatial-operators.adoc
+++ b/cql2/standard/annex_ats_spatial-operators.adoc
@@ -18,7 +18,7 @@
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_DISJOINT spatial operator
+|Test purpose: | Test the S_DISJOINT spatial comparison function
 |Test method: | 
 Given:
 
@@ -49,7 +49,7 @@ Then:
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_EQUALS spatial operator
+|Test purpose: | Test the S_EQUALS spatial comparison function
 |Test method: | 
 Given:
 
@@ -76,7 +76,7 @@ Then:
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_TOUCHES spatial operator
+|Test purpose: | Test the S_TOUCHES spatial comparison function
 |Test method: | 
 Given:
 
@@ -102,7 +102,7 @@ Then:
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_CROSSES spatial operator
+|Test purpose: | Test the S_CROSSES spatial comparison function
 |Test method: | 
 Given:
 
@@ -128,7 +128,7 @@ Then:
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_WITHIN spatial operator
+|Test purpose: | Test the S_WITHIN spatial comparison function
 |Test method: | 
 Given:
 
@@ -156,7 +156,7 @@ Then:
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_CONTAINS spatial operator
+|Test purpose: | Test the S_CONTAINS spatial comparison function
 |Test method: | 
 Given:
 
@@ -185,7 +185,7 @@ Then:
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-operators,/req/{conf-class}/spatial-operators>>
-|Test purpose: | Test the S_OVERLAPS spatial operator
+|Test purpose: | Test the S_OVERLAPS spatial comparison function
 |Test method: | 
 Given:
 

--- a/cql2/standard/annex_ats_temporal-operators.adoc
+++ b/cql2/standard/annex_ats_temporal-operators.adoc
@@ -20,7 +20,7 @@ The term "temporal data type" is used for the following data types: Timestamp, D
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_temporal-predicates,/req/{conf-class}/temporal-predicates>>, <<req_{conf-class}_temporal-operators,/req/{conf-class}/temporal-operators>>
-|Test purpose: | Test the T_AFTER, T_BEFORE, T_DISJOINT, T_EQUALS, T_INTERSECTS operators
+|Test purpose: | Test the T_AFTER, T_BEFORE, T_DISJOINT, T_EQUALS, T_INTERSECTS temporal comparison functions.
 |Test method: | 
 Given:
 
@@ -66,7 +66,7 @@ Then:
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_temporal-predicates,/req/{conf-class}/temporal-predicates>>, <<req_{conf-class}_temporal-operators,/req/{conf-class}/temporal-operators>>
-|Test purpose: | Test the temporal operators with intervals
+|Test purpose: | Test the temporal comparison functions with intervals
 |Test method: | 
 Given:
 

--- a/cql2/standard/clause_2_conformance.adoc
+++ b/cql2/standard/clause_2_conformance.adoc
@@ -60,11 +60,11 @@ The <<rc_accent-insensitive-comparison,Accent-insensitive Comparison>> requireme
 
 * accenti
 
-The <<rc_basic-spatial-operators,Basic Spatial Operators>> requirements class specifies minimal requirements for servers that support spatial operators. Only the following spatial operator must be supported:
+The <<rc_basic-spatial-operators,Basic Spatial Operators>> requirements class specifies minimal requirements for servers that support standardized spatial comparison function. Only the following spatial comparison function must be supported:
 
 * s_intersects
 
-The <<rc_spatial-operators,Spatial Operators>> requirements class specifies requirements for servers that support a richer set of spatial operators.  The list of additional spatial operators that must be supported is:
+The <<rc_spatial-operators,Spatial Operators>> requirements class specifies requirements for servers that support a richer set of standardized spatial comparison functions.  The list of additional spatial comparison functions that must be supported is:
 
 * s_contains
 * s_crosses
@@ -75,8 +75,8 @@ The <<rc_spatial-operators,Spatial Operators>> requirements class specifies requ
 * s_within
 
 The <<rc_temporal-operators,Temporal Operators>> requirements
-class specifies requirements for servers that support temporal operators. 
-The list of temporal operators that must be supported is:
+class specifies requirements for servers that support standardized temporal comparison function. 
+The list of temporal comparison function that must be supported is:
 
 * t_after
 * t_before
@@ -95,8 +95,8 @@ The list of temporal operators that must be supported is:
 * t_starts
 
 The <<rc_array-operators,Array Operators>> requirements class specifies
-requirements for comparison operators for sets of values. 
-The operators that must be supported are:
+requirements for standardized array comparison functions for sets of values. 
+The array comparison functions that must be supported are:
 
 * a_containedby
 * a_contains

--- a/cql2/standard/clause_6_basic_cql2.adoc
+++ b/cql2/standard/clause_6_basic_cql2.adoc
@@ -94,7 +94,7 @@ CQL2 supports two commonly used granularities: a second or smaller (data type "t
 
 If timezone information is important for the intended use, then the "date" data type should not be used and the temporal information should be provided as an interval with start and end timestamps.
 
-NOTE: While instants (timestamps and dates) are scalar data types that can be used with the basic comparison operators, intervals are more complex data types. Support for intervals is added in the requirements class <<rc_temporal-operators,Temporal Operators>> where intervals can be provided as arguments in temporal operators.
+NOTE: While instants (timestamps and dates) are scalar data types that can be used with the basic comparison operators, intervals are more complex data types. Support for intervals is added in the requirements class <<rc_temporal-operators,Temporal Operators>> where intervals can be provided as arguments in temporal comparison functions.
 
 For timestamp and date values representations based on RFC 3339 are used:
 

--- a/cql2/standard/clause_7_enhanced.adoc
+++ b/cql2/standard/clause_7_enhanced.adoc
@@ -195,7 +195,7 @@ Like `CASEI`, the `ACCENTI` function returns a string typed representation of th
 
 include::requirements/requirements_class_basic-spatial-operators.adoc[]
 
-A _spatial predicate_ evaluates two geometry-valued expressions to determine if the expressions satisfy the requirements of the specified spatial operator.
+A _spatial predicate_ evaluates two geometry-valued expressions to determine if the expressions satisfy the requirements of the specified spatial comparison function.
 
 ==== Spatial data types and literal values
 
@@ -216,7 +216,7 @@ Existing representations are in general used for literal values:
 * Text: an OGC Well-Known Text (WKT) literal (see clause 7 of <<ogc06-103r4,Simple feature access - Part 1: Common architecture>>)
 * JSON: a GeoJSON geometry object (see clause 3.1 of <<GeoJSON,GeoJSON>>)
 
-The BBox data type is an exception as it is not specified in WKT. In the Text representation, the type is encoded as a `BBOX()` operator with four or six numerical arguments, depending on whether the coordinates include a vertical axis (height or depth):
+The BBox data type is an exception as it is not specified in WKT. In the Text representation, the type is encoded as a `BBOX()` function with four or six numerical arguments, depending on whether the coordinates include a vertical axis (height or depth):
 
 * Lower left corner, coordinate axis 1
 * Lower left corner, coordinate axis 2
@@ -281,7 +281,7 @@ BBOX(160.6,-55.95,-170,-25.89)
 
 ==== Spatial Operators
 
-In this conformance class, the only required spatial operator is _intersects_. Additional spatial operators are specified in the <<rc_spatial-operators,Spatial Operators>> requirements class.
+In this conformance class, the only required standardized spatial comparison function is _intersects_. Additional standardized spatial comparison functions are specified in the <<rc_spatial-operators,Spatial Operators>> requirements class.
 
 include::requirements/basic-spatial-operators/REQ_spatial-predicate.adoc[]
 
@@ -338,17 +338,17 @@ Note that the values of the `filter-crs` and `filter` parameters have not been p
 
 include::requirements/requirements_class_spatial-operators.adoc[]
 
-This requirement adds a set of Dimensionally Extended Nine-intersection Model (DE-9IM) relation operators that may be used to add spatial predicates to a CQL2 filter expression.
+This requirement adds a set of Dimensionally Extended Nine-intersection Model (DE-9IM) relation operators that may be used to add spatial predicates to a CQL2 filter expression.  These operators are implemented in CQL2 as standardized functions.
 
 include::requirements/spatial-operators/REQ_spatial-operators.adoc[]
 
-The following table lists the mathematical definitions of each spatial operator as described in <<ogc06-103r4,OpenGIS® Implementation Standard for Geographic information - Simple feature access - Part 1: Common architecture>>. `a` and `b` are geometries, `I(a)` is the set of all positions in the interior of the geometry (i.e., all positions on the geometry, but which are not on the boundary), and `E(a)` is the set of all exterior positions (i.e., all positions except those in the interior or on the boundary of the geometry).
+The following table lists the mathematical definitions of each standardized spatial comparison function as described in <<ogc06-103r4,OpenGIS® Implementation Standard for Geographic information - Simple feature access - Part 1: Common architecture>>. `a` and `b` are geometries, `I(a)` is the set of all positions in the interior of the geometry (i.e., all positions on the geometry, but which are not on the boundary), and `E(a)` is the set of all exterior positions (i.e., all positions except those in the interior or on the boundary of the geometry).
 
 [reftext='{table-caption} {counter:table-num}']
-.Mathematical definitions of spatial operators
+.Mathematical definitions of standardized spatial comparison functions
 [width=100%,cols="30,70",options="header"]
 |===
-|Spatial operator |Definition
+|Spatial comparison function |Definition
 |S_CONTAINS |S_CONTAINS(a,b) &#x2b04; b WITHIN a
 |S_CROSSES |S_CROSSES(a,b) &#x2b04; [I(a) &#x2229; I(b) &#x2260; &#x2205;) &#x2227; (a &#x2229; b &#x2260; a) &#x2227; (a &#x2229; b &#x2260; b)]
 |S_DISJOINT |S_DISJOINT(a,b) &#x2b04; a &#x2229; b = &#x2205;
@@ -359,7 +359,7 @@ The following table lists the mathematical definitions of each spatial operator 
 |S_WITHIN |S_WITHIN(a,b) &#x2b04; (a &#x2229; b = a) &#x2227; (I(a) &#x2229; E(b) = &#x2205;)
 |===
 
-The following diagrams illustrate the meaning of the `S_CROSSES`, `S_OVERLAPS`, `S_TOUCHES` and `S_WITHIN` operators.
+The following diagrams illustrate the meaning of the `S_CROSSES`, `S_OVERLAPS`, `S_TOUCHES` and `S_WITHIN` spatial comparison functions.
 
 [#figure4]
 .Examples of the S_CROSSES relationship Polygon/LineString(a) and LineString/LineString(b).
@@ -418,7 +418,7 @@ S_CROSSES(road,POLYGON((43.7286 -79.2986, 43.7311 -79.2996, 43.7323 -79.2972,
 
 include::requirements/requirements_class_temporal-operators.adoc[]
 
-A temporal predicate evaluates two time-valued expressions to determine, if the expressions satisfy the requirements of the specified temporal operator.
+A temporal predicate evaluates two time-valued expressions to determine, if the expressions satisfy the requirements of the specified standardized temporal comparison function.
 
 The operands in a temporal predicate are temporal geometries. A temporal geometry is either an instant or an interval.
 
@@ -464,18 +464,18 @@ INTERVAL('2019-09-09', '..')
 
 ==== Temporal Operators 
 
-The temporal operators in CQL2 are based on the definitions in the <<owl-time,W3C/OGC Time Ontology in OWL>>. 
+The standardized temporal comparison functions in CQL2 are based on the temporal operator definitions in the <<owl-time,W3C/OGC Time Ontology in OWL>>. 
 
 NOTE: <<per_basic-cql2_time-instant-comparison,Simple temporal predicates>> involving time instants can also be evaluated using the <<basic-cql2_comparison-predicates,standard comparison operators>>.
 
-The following table specifies the definition of the temporal operators where both operands may be instants or intervals, including mixed combinations.
+The following table specifies the definition of the standardized temporal comparison functions where both operands may be instants or intervals, including mixed combinations.
 
 [[temporal-operators-1]]
 [reftext='{table-caption} {counter:table-num}']
-.Definitions of temporal operators that support both instants and intervals
+.Definitions of standardized temporal comparison functions that support both instants and intervals
 [width=100%,cols="30,70",options="header"]
 |===
-|Temporal operator |Definition (t1: first operand, t2: second operand)
+|Temporal comparison function |Definition (t1: first operand, t2: second operand)
 |T_AFTER |See https://www.w3.org/TR/owl-time/#time:after[after] 
 |T_BEFORE |See https://www.w3.org/TR/owl-time/#time:before[before] 
 |T_DISJOINT |(t1 T_BEFORE t2) OR (t1 T_AFTER t2)
@@ -483,14 +483,14 @@ The following table specifies the definition of the temporal operators where bot
 |T_INTERSECTS |NOT (t1 T_DISJOINT t2)
 |===
 
-Additional temporal operators are available, but only applicable for intervals. Using these operators with instants will result in a client error.
+Additional temporal comparison functions are available, but only applicable for intervals. Using these functions with instants will result in a client error.
 
 [[temporal-operators-2]]
 [reftext='{table-caption} {counter:table-num}']
-.Definitions of temporal operators between intervals
+.Definitions of standardized temporal comparison function between intervals
 [width=100%,cols="30,70",options="header"]
 |===
-|Temporal operator |Definition
+|Temporal comparison function |Definition
 |T_CONTAINS |See https://www.w3.org/TR/owl-time/#time:intervalContains[intervalContains]
 |T_DURING |See https://www.w3.org/TR/owl-time/#time:intervalDuring[intervalDuring]
 |T_FINISHEDBY |See https://www.w3.org/TR/owl-time/#time:intervalFinishedBy[intervalFinishedBy]
@@ -503,7 +503,7 @@ Additional temporal operators are available, but only applicable for intervals. 
 |T_STARTS |See https://www.w3.org/TR/owl-time/#time:intervalStartedBy[intervalStartedBy]
 |===
 
-The following diagram illustrates the meaning of most of the temporal operators when applied to intervals.
+The following diagram illustrates the meaning of most of the standardized temporal comparison functions when applied to intervals.
 
 [#figure5]
 .The elementary relations between time intervals
@@ -600,7 +600,8 @@ a geometry, an interval, or another array.
 
 Array expressions can be tested in a predicate for equality, if one array
 is a subset of another, if one array is a superset of another or if two
-arrays overlap or share elements.
+arrays overlap or share elements using a standardized set of array comparison 
+functions.
 
 include::requirements/array-operators/REQ_array-predicates.adoc[]
 

--- a/cql2/standard/recommendations/cql2-json/PER_basic-cql2.adoc
+++ b/cql2/standard/recommendations/cql2-json/PER_basic-cql2.adoc
@@ -4,6 +4,6 @@
 ^|*Permission {counter:per-id}* |*/per/cql2-json/basic-cql2*
 ^|A |The server MAY not support 
 
-* the schema component "#/$defs/propertyRef" in an operand of a comparison, spatial, temporal or array operator starting with the second operand,
-* the schema components "\#/$defs/scalarLiteral", "#/$defs/spatialLiteral", "\#/$defs/temporalLiteral" or "#/$defs/arrayLiteral" in the first operand of a comparison, spatial, temporal or array operator.
+* the schema component "#/$defs/propertyRef" in an operand of a comparison operator, standardized spatial, temporal or array comparison functions starting with the second operand,
+* the schema components "\#/$defs/scalarLiteral", "#/$defs/spatialLiteral", "\#/$defs/temporalLiteral" or "#/$defs/arrayLiteral" in the first operand of a comparison operator, standardized spatial, temporal or array comparison function.
 |===

--- a/cql2/standard/requirements/array-operators/REQ_array-predicates.adoc
+++ b/cql2/standard/requirements/array-operators/REQ_array-predicates.adoc
@@ -8,7 +8,7 @@ with the exception of the following rules:
 * `function` in `arrayExpression`, `arrayElement`
 * `arithmeticExpression` and `function` in `arrayElement`.
 ^|B |Both array expressions SHALL be evaluated as sets. No inherent order SHALL be implied in a array of values.
-^|C |The semantics of the array operators SHALL be evaluated as follows:
+^|C |The semantics of the standardized array comparison functions SHALL be evaluated as follows:
 
 * `A_EQUALS` evaluates to the Boolean value `TRUE`, if both sets are identical; otherwise the predicate 
 SHALL evaluate to the Boolean value `FALSE`.

--- a/cql2/standard/requirements/basic-spatial-operators/REQ_spatial-operators.adoc
+++ b/cql2/standard/requirements/basic-spatial-operators/REQ_spatial-operators.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/basic-spatial-operators/spatial-operators*
-^|A |The server SHALL support the `S_INTERSECTS` operator as defined by the BNF rule `spatialOperator` in <<cql2-bnf>>.
-^|B |All supported spatial operators SHALL be evaluated as defined in clause 6.1.15 of <<ogc06-103r4,OpenGIS® Implementation Standard for Geographic information - Simple feature access - Part 1: Common architecture>> (except that in CQL2 the predicates evaluate to a Boolean, not an Integer).
+^|A |The server SHALL support the standardized `S_INTERSECTS` spatial comparison function as defined by the BNF rule `spatialFunction` in <<cql2-bnf>>.
+^|B |All supported standardized spatial comparison functions SHALL be evaluated as defined in clause 6.1.15 of <<ogc06-103r4,OpenGIS® Implementation Standard for Geographic information - Simple feature access - Part 1: Common architecture>> (except that in CQL2 the predicates evaluate to a Boolean, not an Integer).
 |===

--- a/cql2/standard/requirements/basic-spatial-operators/REQ_spatial-predicate.adoc
+++ b/cql2/standard/requirements/basic-spatial-operators/REQ_spatial-predicate.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/basic-spatial-operators/spatial-predicate*
-^|A |If the requirements of the spatial operator are satisfied, then the predicate SHALL evaluate to the Boolean value `TRUE`. Otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
+^|A |If the requirements of the standardized spatial comparison function are satisfied, then the predicate SHALL evaluate to the Boolean value `TRUE`. Otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
 |===

--- a/cql2/standard/requirements/cql2-json/REQ_property-property.adoc
+++ b/cql2/standard/requirements/cql2-json/REQ_property-property.adoc
@@ -5,6 +5,6 @@
 ^|Condition |Server implements requirements class <<rc_property-property,Property-Property Comparisons>>
 ^|A |In addition to the <<req_cql2-json_basic-cql2,Basic CQL2>> requirement, the server SHALL be able to parse and evaluate filter expressions encoded as JSON that use 
 
-* the schema component "#/$defs/propertyRef" in an operand of a comparison, spatial, temporal or array operator starting with the second operand,
-* the schema components "\#/$defs/scalarLiteral", "#/$defs/spatialLiteral", "\#/$defs/temporalLiteral" or "#/$defs/arrayLiteral" in the first operand of a comparison, spatial, temporal or array operator.
+* the schema component "#/$defs/propertyRef" in an operand of a comparison operator, standardized spatial, temporal or array comparison function starting with the second operand,
+* the schema components "\#/$defs/scalarLiteral", "#/$defs/spatialLiteral", "\#/$defs/temporalLiteral" or "#/$defs/arrayLiteral" in the first operand of a comparison operator, standardized spatial, temporal or array comparison function.
 |===

--- a/cql2/standard/requirements/cql2-text/REQ_accent-insensitive-comparison.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_accent-insensitive-comparison.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-text/accent-insensitive-comparison* 
 ^|Condition |Server implements requirements class <<rc_accent-insensitive-comparison,Accent-insensitive Comparisons>>
-^|A |The server SHALL be able to parse and evaluate all spatial operators encoded as a text string that validate against the BNF production fragments identified in the <<rc_accent-insensitive-comparison,Accent-insensitive Comparisons>> requirements class.
+^|A |The server SHALL be able to parse and evaluate all standardized functions encoded as a text string that validate against the BNF production fragments identified in the <<rc_accent-insensitive-comparison,Accent-insensitive Comparisons>> requirements class.
 |===

--- a/cql2/standard/requirements/cql2-text/REQ_basic-spatial-operators.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_basic-spatial-operators.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-text/basic-spatial-operators* 
 ^|Condition |Server implements requirements class <<rc_basic-spatial-operators,Basic Spatial Operators>>
-^|A |The server SHALL be able to parse and evaluate all spatial operators encoded as a text string that validate against the BNF production fragments identified in the <<rc_basic-spatial-operators,Basic Spatial Operators>> requirements class.
+^|A |The server SHALL be able to parse and evaluate all standardized spatial comparison functions encoded as a text string that validate against the BNF production fragments identified in the <<rc_basic-spatial-operators,Basic Spatial Operators>> requirements class.
 |===

--- a/cql2/standard/requirements/cql2-text/REQ_case-insensitive-comparison.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_case-insensitive-comparison.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-text/case-insensitive-comparison* 
 ^|Condition |Server implements requirements class <<rc_case-insensitive-comparison,Case-insensitive Comparisons>>
-^|A |The server SHALL be able to parse and evaluate all spatial operators encoded as a text string that validate against the BNF production fragments identified in the <<rc_case-insensitive-comparison,Case-insensitive Comparisons>> requirements class.
+^|A |The server SHALL be able to parse and evaluate all standardized functions encoded as a text string that validate against the BNF production fragments identified in the <<rc_case-insensitive-comparison,Case-insensitive Comparisons>> requirements class.
 |===

--- a/cql2/standard/requirements/cql2-text/REQ_spatial-operators.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_spatial-operators.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-text/spatial-operators* 
 ^|Condition |Server implements requirements class <<rc_spatial-operators,Spatial Operators>>
-^|A |The server SHALL be able to parse and evaluate all spatial operators encoded as a text string that validate against the BNF production fragments identified in the <<rc_spatial-operators,Spatial Operators>> requirements class.
+^|A |The server SHALL be able to parse and evaluate all standardized spatial comparison functions encoded as a text string that validate against the BNF production fragments identified in the <<rc_spatial-operators,Spatial Operators>> requirements class.
 |===

--- a/cql2/standard/requirements/cql2-text/REQ_temporal-operators.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_temporal-operators.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-text/temporal-operators* 
 ^|Condition |Server implements requirements class <<rc_temporal-operators,Temporal Operators>>
-^|A |The server SHALL be able to parse and evaluate all spatial operators encoded as a text string that validate against the BNF production fragments identified in the <<rc_temporal-operators,Temporal Operators>> requirements class.
+^|A |The server SHALL be able to parse and evaluate all standardzied temporal comparison functions encoded as a text string that validate against the BNF production fragments identified in the <<rc_temporal-operators,Temporal Operators>> requirements class.
 |===

--- a/cql2/standard/requirements/spatial-operators/REQ_spatial-operators.adoc
+++ b/cql2/standard/requirements/spatial-operators/REQ_spatial-operators.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/spatial-operators/spatial-operators*
-^|A |The server SHALL support all spatial operators as defined by the BNF rule `spatialOperator` in <<cql2-bnf>>.
+^|A |The server SHALL support all standardized spatial comparison functions as defined by the BNF rule `spatialFunction` in <<cql2-bnf>>.
 |===

--- a/cql2/standard/requirements/temporal-operators/REQ_temporal-predicates.adoc
+++ b/cql2/standard/requirements/temporal-operators/REQ_temporal-predicates.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/temporal-operators/temporal-predicates* 
-^|A |If the requirements of the temporal operator are satisfied, then the predicate SHALL evaluate to the Boolean value `TRUE`. Otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
+^|A |If the requirements of the standardized temporal comparison function are satisfied, then the predicate SHALL evaluate to the Boolean value `TRUE`. Otherwise the predicate SHALL evaluate to the Boolean value `FALSE`.
 |===

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -105,16 +105,18 @@ isNullOperand = characterClause
 
 #=============================================================================#
 # A spatial predicate evaluates if two spatial expressions satisfy the
-# specified spatial operator.
+# condition implied by a standardized spatial comparison function.  If the
+# conditions of the spatial comparison function are met, the function returns
+# a Boolean value of true.  Otherwise the function returns false.
 #=============================================================================#
-spatialPredicate =  spatialOperator
+spatialPredicate =  spatialFunction
                     leftParen geomExpression comma geomExpression rightParen;
 
-# NOTE: The buffer operators (DWITHIN and BEYOND) are not included because
+# NOTE: The buffer functions (DWITHIN and BEYOND) are not included because
 #       these are outside the scope of a "simple" core for CQL2.  These
 #       can be added as extensions.
 #
-spatialOperator = "S_INTERSECTS"
+spatialFunction = "S_INTERSECTS"
                 | "S_EQUALS"
                 | "S_DISJOINT"
                 | "S_TOUCHES"
@@ -133,16 +135,18 @@ geomExpression = spatialLiteral
 
 #=============================================================================#
 # A temporal predicate evaluates if two temporal expressions satisfy the
-# specified temporal operator.
+# condition implied by a standardized temporal comparison function.  If the
+# conditions of the temporal comparison function are met, the function returns
+# a Boolean value of true.  Otherwise the function returns false.
 #=============================================================================#
-temporalPredicate = temporalOperator 
+temporalPredicate = temporalFunction 
                     leftParen temporalExpression comma temporalExpression rightParen;
 
 temporalExpression = temporalLiteral
                    | propertyName
                    | function;
 
-temporalOperator = "T_AFTER"
+temporalFunction = "T_AFTER"
                  | "T_BEFORE"
                  | "T_CONTAINS"
                  | "T_DISJOINT"
@@ -159,12 +163,12 @@ temporalOperator = "T_AFTER"
                  | "T_STARTS";
 
 #=============================================================================#
-# An array predicate evaluates if two array expressions statisfy the
-# specified array operator.  Arrays can be equal, one is a superset of
-# the other, one is a subset of the other and the two arrays have
-# overlapping elements.
+# An array predicate evaluates if two array expressions satisfy the
+# condition implied by a standardized array comparison function.  If the
+# conditions of the array comparison function are met, the function returns
+# a Boolean value of true.  Otherwise the function returns false.
 #=============================================================================#
-arrayPredicate = arrayOperator
+arrayPredicate = arrayFunction
                  leftParen arrayExpression comma arrayExpression rightParen;
 
 arrayExpression = arrayLiteral
@@ -189,7 +193,7 @@ arrayElement = characterClause
              | propertyName
              | function;
 
-arrayOperator = "A_EQUALS"
+arrayFunction = "A_EQUALS"
               | "A_CONTAINS"
               | "A_CONTAINEDBY"
               | "A_OVERLAPS";


### PR DESCRIPTION
Resolve issue 776 by refering to all spatial, temporal and array "operators" as standardized functions.