### PR TITLE
Update datetime ABNF to use interval-bounded

### DIFF
--- a/core/standard/requirements/core/REQ_fc-time-response.adoc
+++ b/core/standard/requirements/core/REQ_fc-time-response.adoc
@@ -11,7 +11,7 @@
 interval-bounded            = date-time "/" date-time
 interval-half-bounded-start = [".."] "/" date-time
 interval-half-bounded-end   = date-time "/" [".."]
-interval                    = interval-closed / interval-half-bounded-start / interval-half-bounded-end
+interval                    = interval-bounded / interval-half-bounded-start / interval-half-bounded-end
 datetime                    = date-time / interval
 ```
 ^|E |The syntax of `date-time` is specified by link:https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6[RFC 3339, 5.6].


### PR DESCRIPTION
The ABNF syntax for [the `datetime` query parameter](https://docs.opengeospatial.org/is/17-069r4/17-069r4.html#_parameter_datetime) mentions `interval-closed`.  It looks like this should be `interval-bounded` instead.

https://github.com/opengeospatial/ogcapi-features/blob/9f4ec94724ee842aad8bf677a69fe145cb78d6e8/core/standard/requirements/core/REQ_fc-time-response.adoc#L11-L15