### PR TITLE
Clean up minor inconsistencies in cql2 schemas.

### DIFF
--- a/cql2/standard/schema/cql2.json
+++ b/cql2/standard/schema/cql2.json
@@ -101,14 +101,9 @@
       "type": "array",
       "minItems": 2,
       "maxItems": 2,
-      "prefixItems": [
-        {
-          "$ref": "#/$defs/scalarExpression"
-        },
-        {
-          "$ref": "#/$defs/scalarExpression"
-        }
-      ]
+      "items": {
+        "$ref": "#/$defs/scalarExpression"
+      }
     },
 
     "scalarExpression": {
@@ -156,16 +151,17 @@
       }
     },
     "isLikeOperands": {
-          "type": "array",
-          "prefixItems": [
-            {
-              "$ref": "#/$defs/characterExpression"
-            },
-            {
-              "$ref": "#/$defs/patternExpression"
-            }
-          ],
-          "additionalItems": false
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/characterExpression"
+        },
+        {
+          "$ref": "#/$defs/patternExpression"
+        }
+      ]
     },
 
     "patternExpression": {
@@ -248,6 +244,8 @@
     },
     "inListOperands": {
       "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
       "prefixItems": [
         {
           "$ref": "#/$defs/scalarExpression"
@@ -258,8 +256,7 @@
             "$ref": "#/$defs/scalarExpression"
           }
         }
-      ],
-      "additionalItems": false
+      ]
     },
 
     "isNullPredicate": {
@@ -319,15 +316,11 @@
     },
     "spatialOperands": {
       "type": "array",
-      "prefixItems": [
-        {
-          "$ref": "#/$defs/geomExpression"
-        },
-        {
-          "$ref": "#/$defs/geomExpression"
-        }
-      ],
-      "additionalItems": false
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "$ref": "#/$defs/geomExpression"
+      }
     },
     "geomExpression": {
       "oneOf": [
@@ -374,15 +367,11 @@
     },
     "temporalOperands": {
       "type": "array",
-      "prefixItems": [
-        {
-          "$ref": "#/$defs/temporalExpression"
-        },
-        {
-          "$ref": "#/$defs/temporalExpression"
-        }
-      ],
-      "additionalItems": false
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "$ref": "#/$defs/temporalExpression"
+      }
     },
     "temporalExpression": {
       "oneOf": [
@@ -466,7 +455,7 @@
       "properties": {
         "op": {
           "type": "string",
-          "enum": [ "+", "-", "*", "/", "^" ]
+          "enum": [ "+", "-", "*", "/", "^", "%", "div" ]
         },
         "args": {
           "$ref": "#/$defs/arithmeticOperands"
@@ -582,7 +571,7 @@
                 "$ref": "#/$defs/temporalExpression"
               },
               {
-                "$ref": "#/$defs/arrayLiteral"
+                "$ref": "#/$defs/arrayExpression"
               }
             ]
           }

--- a/cql2/standard/schema/cql2.yml
+++ b/cql2/standard/schema/cql2.yml
@@ -65,12 +65,12 @@ components:
         op:
           type: string
           enum:
-            - =
-            - <
-            - >
+            - '='
+            - '<>'
+            - '<'
+            - '>'
             - '<='
             - '>='
-            - <>
         args:
           $ref: '#/components/schemas/scalarOperands'
     scalarOperands:
@@ -107,9 +107,12 @@ components:
       minItems: 2
       maxItems: 2
       items:
-        # The second argument is a string or a CASEI or
-        # ACCENTI call with a str.
-        $ref: '#/components/schemas/characterExpression'
+        oneOf:
+          - $ref: '#/components/schemas/characterExpression'
+          - $ref: '#/components/schemas/patternExpression'
+      description: >-
+        The first argument is a characterExpression and the second item
+        is a patternExpression.
     patternExpression:
       oneOf:
         - type: object
@@ -163,13 +166,17 @@ components:
           $ref: '#/components/schemas/inListOperands'
     inListOperands:
       type: array
+      minItems: 2
+      maxItems: 2
       items:
-        # the first item is always a scalarExpression, the second an array
         oneOf:
           - $ref: '#/components/schemas/scalarExpression'
           - type: array
             items:
               $ref: '#/components/schemas/scalarExpression'
+      description: >-
+        The first item is a scalarExpression and the second item is an array
+        of scalarExpression. 
     isNullPredicate:
       type: object
       required:
@@ -299,11 +306,13 @@ components:
         op:
           type: string
           enum:
-            - +
+            - '+'
             - '-'
             - '*'
-            - /
+            - '/'
             - '^'
+            - '%'
+            - 'div'
         args:
           $ref: '#/components/schemas/arithmeticOperands'
     arithmeticOperands:


### PR DESCRIPTION
While writing a parser I have spent a lot of time switching back and forth between the schema formats leading me to notice a few inconsistencies between the different formats so I have attempted to address them. I tried not to do anything dramatic, just align everything together a little better. 

The biggest issue I have had is `%` and `div` only existing in the cql2.bnf file, but there were lots of other little things that added up. I have attempted to provide detailed justifications for everything below. 

### Both cql2.json and cql2.yaml

- Added `%` and `div` to arithmetic op enums.
    - They are included in the bnf, as well as the text of the standard [clause_7_enhanced.adoc?plain=1#L790-L792](https://github.com/opengeospatial/ogcapi-features/blob/master/cql2/standard/clause_7_enhanced.adoc?plain=1#L790-L792).

### cql2.json

- Switched `prefixItems` to `items` when it was used for objects of the same type. 
    - This better aligns with the yaml schema. 
    - It felt easier to read.
-  Replaced all `additionalItems` with `minItems` and `maxItems`.
    - `prefixItems` does not require all items in the array to exist. So, `minItems` is needed to require all of them.
    - More consistent within the schema and better aligns with the yaml schema.
    - The 2020 json-schema draft removed `additionalItems` so it seemed better to remove and be forward compatible. 
- Aligned function array items with yaml. `arrayLiteral` -> `arrayExpression`.
    - The rest of the items are `Expressions` in both the json and yaml so I figured this would be the one to adjust.
    - **Note:** Switching to `Literal` (or `Instance` per #790) types and adding `function` and `property` directly would better align to the bnf file and feels easier to read. But I did not want to do that without discussion. This would also apply to various other locations where similar things are done as well. 

### cql2.yaml

- Moved comments related to json `prefixItems` to `description` within the yaml.
    - Based on other examples I have seen this seems to be the more acceptable place for that information.
    - **Note:** A move to OpenAPI 3.1 would support `prefixItems` and no longer need these comments. I figured that would need additional discussion though. 
- Added `patternExpression` to `isLikeOperands`. 
    - While it is already a subset of `characterExpression` this aligns with the json better, and makes the description more useful. 
    - Would need to be included anyways for `prefixItems` if an OpenAPI 3.1 upgrade happened.
- Add `minItems` and `maxItems` to `inListOperands`. 
    - This aligns with the other schemas. I think it was just missing before. 
- Quoted all the arithmetic and binary operators for consistency within the schema. 
- Adjusted order of arithmetic and binary operator enums for consistency with json and bnf. 