### PR TITLE
Add additional content around escaping in string literals.

### DIFF
--- a/cql2/standard/annex_ats_cql2-text.adoc
+++ b/cql2/standard/annex_ats_cql2-text.adoc
@@ -42,3 +42,24 @@ Then:
 * assert that all conformance tests are successful.
 |===
 
+:conf-test: escaping
+==== Conformance Test {counter:test-id}
+[cols=">20h,<80a",width="100%"]
+|===
+|Test id: | /conf/{conf-class}/{conf-test}
+|Requirements: | <<req_{conf-class}_escaping,/req/{conf-class}/escaping>>
+|Test purpose: | Test escaping in string literals.
+|Test method: | 
+Given:
+
+* One of more data sources containing string literals with escaped character sequences.
+
+When:
+
+T.B.D.
+
+Then:
+
+T.B.D.
+
+|===

--- a/cql2/standard/annex_ats_cql2-text.adoc
+++ b/cql2/standard/annex_ats_cql2-text.adoc
@@ -52,14 +52,14 @@ Then:
 |Test method: | 
 Given:
 
-* One of more data sources containing string literals with escaped character sequences.
+* One of more data sources containing string literals with embeded single quotation (`'`) and/or BELL, and/or BACKSPACE, and/or HORIZONTAL TAB, and/or NEWLINE, and/or VERTICAL TAB, and/or FORM FEED, and/or CARRIAGE RETURN characters.
 
 When:
 
-T.B.D.
+Decode each string literal.
 
 Then:
 
-T.B.D.
+* assert that the escaped embedded characters have been correctly recovered.
 
 |===

--- a/cql2/standard/clause_6_basic_cql2.adoc
+++ b/cql2/standard/clause_6_basic_cql2.adoc
@@ -146,7 +146,7 @@ DATE('1969-07-20')
 
 ==== Escaping in string literals
 
-In general, escaping special character sequences in a string literal will be hanldering according to the rules of the specific encoding being used.  For example, for the JSON encoding of CQL2, an embeded newline in a string literal would be encoded as `\n`.  If, however, an XML encoding of CQL2 existed the embeded newline character would be encoded as `&#xA`.  Furthermore, additional processing of a string literal may be necessary before it can be passed down to an underlying platform (e.g. RDBMS) for further handling.
+In general, escaping special character sequences in a string literal will be handled according to the rules of the specific encoding being used.  For example, for the JSON encoding of CQL2, an embeded newline in a string literal would be encoded as `\n`.  If, however, an XML encoding of CQL2 existed the embeded newline character would be encoded as `&#xA`.  Furthermore, additional processing of a string literal may be necessary before it can be passed down to an underlying platform (e.g. RDBMS) for further handling.
 
 For the text encoding of CQL2 see <<cql2-text>> and requirement <<req_cql2-text_escaping>> for additional requirements concerning escaping in string literals.
 

--- a/cql2/standard/clause_6_basic_cql2.adoc
+++ b/cql2/standard/clause_6_basic_cql2.adoc
@@ -86,7 +86,7 @@ The scalar data types are:
 * "timestamp": an instant with a granularity of a second or smaller (literal rule: `timestampLiteral`)
 * "date": an instant with a granularity of a day (literal rule: `dateLiteral`)
 
-For character string, numeric and boolean literals, the standard representations are used. For character string literals, embeded quotes are escaped using two consecutive single quotes (i.e. `''`).
+For character string, numeric and boolean literals, the standard representations are used. 
 
 Conceptually, an instant is a "temporal entity with zero extent or duration" [<<owl-time,Time Ontology in OWL>>]. In practice, the temporal position of an instant is described using data types where each value has some duration or granularity that is sufficient for the intended use of the data. 
 
@@ -143,6 +143,12 @@ DATE('1969-07-20')
 ----
 
 ====
+
+==== Escaping in string literals
+
+In general, escaping special character sequences in a string literal will be hanldering according to the rules of the specific encoding being used.  For example, for the JSON encoding of CQL2, an embeded newline in a string literal would be encoded as `\n`.  If, however, an XML encoding of CQL2 existed the embeded newline character would be encoded as `&#xA`.  Furthermore, additional processing of a string literal may be necessary before it can be passed down to an underlying platform (e.g. RDBMS) for further handling.
+
+For the text encoding of CQL2 see <<cql2-text>> and requirement <<req_cql2-text_escaping>> for additional requirements concerning escaping in string literals.
 
 [[type-casts]]
 ==== Type casts

--- a/cql2/standard/clause_8_encodings.adoc
+++ b/cql2/standard/clause_8_encodings.adoc
@@ -78,6 +78,8 @@ If a queryable uses a property name that is one of the keywords, the property na
 
 include::requirements/cql2-text/REQ_basic-cql2.adoc[]
 
+include::requirements/cql2-text/REQ_escaping.adoc[]
+
 include::requirements/cql2-text/REQ_advanced-comparison-operators.adoc[]
 
 include::requirements/cql2-text/REQ_case-insensitive-comparison.adoc[]

--- a/cql2/standard/requirements/cql2-text/REQ_escaping.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_escaping.adoc
@@ -2,9 +2,9 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-text/escaping* 
-^|A |The escape character in a string literal SHALL be the backslash (`\\`).
-^|B |Embeded single quotations (`'`) in a string literal SHALL be escaped using a double single quotation (`''`) OR the backslash (`\\`) character.
-^|C | The server SHALL be able to parse the following escaped sequences for encoding control characters in a string literal:
+^|A |The escape character in a character literal SHALL be the backslash (`\\`).
+^|B |Embeded single quotations (`'`) in a character literal SHALL be escaped using a double single quotation (`''`) OR the backslash (`\\`) character.
+^|C | The server SHALL be able to parse the following escaped sequences for encoding control characters in a character literal:
 
 * '\a' BELL CHR(07)
 * '\b' BACKSPACE CHR(08)
@@ -14,6 +14,3 @@
 * '\f' FORM FEED CHR(12)
 * '\r' CARRIAGE RETURN CHR(13)
 |===
-
-
-

--- a/cql2/standard/requirements/cql2-text/REQ_escaping.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_escaping.adoc
@@ -1,0 +1,19 @@
+[[req_cql2-text_escaping]] 
+[width="90%",cols="2,6a"]
+|===
+^|*Requirement {counter:req-id}* |*/req/cql2-text/escaping* 
+^|A |The escape character in a string literal SHALL be the backslash (`\\`).
+^|B |Embeded single quotations (`'`) in a string literal SHALL be escaped using a double single quotation (`''`) OR the backslash (`\\`) character.
+^|C | The server SHALL be able to parse the following escaped sequences for encoding control characters in a string literal:
+
+* '\a' BELL CHR(07)
+* '\b' BACKSPACE CHR(08)
+* '\t' HORIZONTAL TAB CHR(09)
+* '\n' NEWLINE CHR(10)
+* '\v' VERTICAL TAB CHR(11)
+* '\f' FORM FEED CHR(12)
+* '\r' CARRIAGE RETURN CHR(13)
+|===
+
+
+

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -369,15 +369,23 @@ characterClause = "CASEI" "(" characterExpression ")"
 #=============================================================================#
 characterLiteral = "'" [ {character} ] "'";
 
-character = alpha | digit | "''";
+character = alpha | digit | whitespace | "''";
 
 # character & digit productions copied from:
 # https://www.w3.org/TR/REC-xml/#charsets
 #
-alpha = "\x0007".."\x000D"     # bell, bs, htab, lf, vt, ff, cr
-      | "\x0020".."\x0026"     # spc, !, ", #, $, %, &
+alpha = "\x0007".."\x0008"     # bell, bs
+      | "\x0021".."\x0026"     # !, ", #, $, %, &
       | "\x0028".."\x002F"     # (, ), *, +, comma, -, ., /
-      | "\x003A".."\xD7FF"     # :,;,<,=,>,?,@,A-Z,[,\,],^,_,`,a-z,{,|,},~,...
+      | "\x003A".."\x0084"     # --+
+      | "\x0086".."\x009F"     #   |
+      | "\x00A1".."\x167F"     #   |
+      | "\x1681".."\x1FFF"     #   |
+      | "\x200B".."\x2027"     #   +-> :,;,<,=,>,?,@,A-Z,[,\,],^,_,`,a-z,...
+      | "\x202A".."\x202E"     #   |
+      | "\x2030".."\x205E"     #   |
+      | "\x2060".."\x2FFF"     #   |
+      | "\x3001".."\xD7FF"     # --+
       | "\xE000".."\xFFFD"     # See note 8.
       | "\x10000".."\x10FFFF"; # See note 9.
 
@@ -431,6 +439,32 @@ alpha = "\x0007".."\x000D"     # bell, bs, htab, lf, vt, ff, cr
 #         Supplementary Private Use Area-A, Supplementary Private Use Area-B
 
 digit = "\x0030".."\x0039";
+
+whitespace = "\x0009"  # Character tabulation
+           | "\x000A"  # Line feed
+           | "\x000B"  # Line tabulation
+           | "\x000C"  # Form feed
+           | "\x000D"  # Carriage return
+           | "\x0020"  # Space
+           | "\x0085"  # Next line
+           | "\x00A0"  # No-break space
+           | "\x1680"  # Ogham space mark
+           | "\x2000"  # En quad
+           | "\x2001"  # Em quad
+           | "\x2002"  # En space
+           | "\x2003"  # Em space
+           | "\x2004"  # Three-per-em space
+           | "\x2005"  # Four-per-em space
+           | "\x2006"  # Six-per-em space
+           | "\x2007"  # Figure space
+           | "\x2008"  # Punctuation space
+           | "\x2009"  # Thin space
+           | "\x200A"  # Hair space
+           | "\x2028"  # Line separator
+           | "\x2029"  # Paragraph separator
+           | "\x202F"  # Narrow no-break space
+           | "\x205F"  # Medium mathematical space
+           | "\x3000"; # Ideographic space
 
 #=============================================================================#
 # Definition of NUMERIC literals

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -369,7 +369,9 @@ characterClause = "CASEI" "(" characterExpression ")"
 #=============================================================================#
 characterLiteral = "'" [ {character} ] "'";
 
-character = alpha | digit | whitespace | "''";
+character = alpha | digit | whitespace | escapeQuote;
+
+escapeQuote = "''" | "\'";
 
 # character & digit productions copied from:
 # https://www.w3.org/TR/REC-xml/#charsets


### PR DESCRIPTION
- Add text indicating that escaping depending on the encoding being used
- Add text indicating that, depending on the back-end platform, additional processing of the string literal may be required.
- Add requirements for escaping in string literals in CQL2 text.

Closes #717 