### PR TITLE
Clarify context of normative statements about link properties

### DIFF
--- a/core/standard/recomendations/core/REC_fc-md-descriptions.adoc
+++ b/core/standard/recomendations/core/REC_fc-md-descriptions.adoc
@@ -2,8 +2,8 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/fc-md-descriptions*
-^|A |If external schemas or descriptions for the dataset exist that provide information about the structure or semantics of the data, a `200`-response SHOULD include links to each of those resources in the `links` property of the response (relation: `describedby`).
-^|B |The `type` link parameter SHOULD be provided for each link. This applies to resources that describe the whole dataset. 
+^|A |If external schemas or descriptions for the dataset exist that provide information about the structure or semantics of the data, a `200`-response SHOULD include links to each of those resources in the `links` property of the response (relation: `describedby`). This applies to resources that describe the whole dataset.
+^|B |The `type` link parameter SHOULD be provided for links in that response where `rel` is `describedby`.  
 ^|C |For resources that describe the contents of a feature collection, the links SHOULD be set in the `links` property of the appropriate object in the `collections` resource.
 ^|D |Examples for descriptions are: XML Schema, Schematron, JSON Schema, RDF Schema, OWL, SHACL, a feature catalogue, etc.
 |===

--- a/core/standard/recomendations/core/REC_sfc-md-links.adoc
+++ b/core/standard/recomendations/core/REC_sfc-md-links.adoc
@@ -7,5 +7,5 @@
 * a link to this response document (relation: `self`),
 * a link to the response document in every other media type supported by the server (relation: `alternate`).
 
-^|B |All links SHOULD include the `rel` and `type` link parameters.
+^|B |All links in that response where `rel` is `self` or `alternate` SHOULD include the `type` link parameter.
 |===

--- a/core/standard/requirements/core/REQ_f-links.adoc
+++ b/core/standard/requirements/core/REQ_f-links.adoc
@@ -8,5 +8,5 @@
 * a link to the response document in every other media type supported by the service (relation: `alternate`), and
 * a link to the feature collection that contains this feature (relation: `collection`).
 
-^|B |All links SHALL include the `rel` and `type` link parameters.
+^|B |All links in that response where `rel` is `self`, `alternate`, or `collection` SHALL include the `type` link parameter.
 |===

--- a/core/standard/requirements/core/REQ_fc-md-items-links.adoc
+++ b/core/standard/requirements/core/REQ_fc-md-items-links.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/fc-md-items-links*
 ^|A |For each feature collection included in the response, the `links` property of the collection SHALL include an item for each supported encoding with a link to the features resource (relation: `items`).
-^|B |All links SHALL include the `rel` and `type` properties.
+^|B |These links (`rel` is `items`) SHALL include the `type` link parameter.
 |===

--- a/core/standard/requirements/core/REQ_fc-md-links.adoc
+++ b/core/standard/requirements/core/REQ_fc-md-links.adoc
@@ -7,5 +7,5 @@
 * a link to this response document (relation: `self`),
 * a link to the response document in every other media type supported by the server (relation: `alternate`).
 
-^|B |All links SHALL include the `rel` and `type` link parameters.
+^|B |All links in that response where `rel` is `self` or `alternate` SHALL include the `type` link parameter.
 |===

--- a/core/standard/requirements/core/REQ_fc-rel-type.adoc
+++ b/core/standard/requirements/core/REQ_fc-rel-type.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/fc-rel-type* 
-^|A |All links SHALL include the `rel` and `type` link parameters.
+^|A |All links in a `200`-response where `rel` is `self`, `alternate`, `next`, or `prev` SHALL include the `type` link parameter.
 |===


### PR DESCRIPTION
Closes #818

It is also redundant to require that `rel` is included in links which are identified by their `rel` - which only has potential to add to any confusion. Redundant reference to `rel` have been removed.