### PR TITLE
GeoJSON 'geometry' can be 'null'

### DIFF
--- a/core/openapi/schemas/featureGeoJSON.yaml
+++ b/core/openapi/schemas/featureGeoJSON.yaml
@@ -9,7 +9,10 @@ properties:
     enum:
       - Feature
   geometry:
-    $ref: geometryGeoJSON.yaml
+    oneOf:
+    - enum:
+      - null
+    - $ref: geometryGeoJSON.yaml
   properties:
     type: object
     nullable: true


### PR DESCRIPTION
Currently, `null` is not allowed, but should be.

Source: https://github.com/opengeospatial/ogcapi-records/pull/262#issuecomment-1557203754

Background: https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2019-10-31-Clarify-Nullable.md