### PR TITLE
ats-basic-cql2: Escaping <=

### DIFF
--- a/cql2/standard/annex_ats_basic-cql2.adoc
+++ b/cql2/standard/annex_ats_basic-cql2.adoc
@@ -239,11 +239,11 @@ Then:
 |===
 |p1 |p2 |p3 |p4 |Expected number of items
 |`pop_other<>1038288` |`name<>'København'` |`pop_other IS NULL` |`name<'København'` |1
-|`pop_other<>1038288` |`name>'København'` |`name<='København'` |`boolean=true` |107
+|`pop_other<>1038288` |`name>'København'` |`name\<='København'` |`boolean=true` |107
 |`start IS NULL` |`pop_other IS NOT NULL` |`pop_other IS NOT NULL` |`pop_other>1038288` |124
 |`pop_other<1038288` |`pop_other>1038288` |`pop_other IS NULL` |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |242
 |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other<1038288` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`name<>'København'` |2
-|`start<=TIMESTAMP('2022-04-16T10:13:19Z')` |`name<>'København'` |`boolean=true` |`name<'København'` |138
+|`start\<=TIMESTAMP('2022-04-16T10:13:19Z')` |`name<>'København'` |`boolean=true` |`name<'København'` |138
 |`pop_other=1038288` |`start IS NULL` |`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean IS NOT NULL` |242
 |`start IS NULL` |`pop_other>1038288` |`start IS NOT NULL` |`name>'København'` |122
 |`pop_other<1038288` |`name<>'København'` |`name='København'` |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |123
@@ -252,66 +252,66 @@ Then:
 |`start IS NOT NULL` |`name>='København'` |`start IS NOT NULL` |`name IS NOT NULL` |3
 |`name IS NULL` |`name<'København'` |`pop_other IS NOT NULL` |`boolean IS NOT NULL` |243
 |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`name>'København'` |`pop_other=1038288` |`name<'København'` |139
-|`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`name<='København'` |`boolean IS NULL` |`name>'København'` |242
+|`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`name\<='København'` |`boolean IS NULL` |`name>'København'` |242
 |`pop_other IS NOT NULL` |`start IS NULL` |`pop_other>=1038288` |`name>'København'` |62
 |`name='København'` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean=true` |`pop_other IS NULL` |243
-|`name>'København'` |`pop_other<1038288` |`pop_other>1038288` |`name<='København'` |122
-|`pop_other<>1038288` |`name='København'` |`name<='København'` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |243
+|`name>'København'` |`pop_other<1038288` |`pop_other>1038288` |`name\<='København'` |122
+|`pop_other<>1038288` |`name='København'` |`name\<='København'` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |243
 |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other=1038288` |`start IS NULL` |3
 |`name<>'København'` |`boolean=true` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`start IS NULL` |242
 |`name IS NULL` |`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`name IS NULL` |243
-|`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`name>'København'` |`start<=TIMESTAMP('2022-04-16T10:13:19Z')` |`name IS NOT NULL` |3
+|`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`name>'København'` |`start\<=TIMESTAMP('2022-04-16T10:13:19Z')` |`name IS NOT NULL` |3
 |`name<>'København'` |`pop_other<>1038288` |`pop_other<1038288` |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |2
 |`boolean IS NULL` |`pop_other>1038288` |`boolean IS NOT NULL` |`pop_other IS NULL` |122
 |`pop_other=1038288` |`start IS NULL` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other IS NOT NULL` |2
 |`pop_other<>1038288` |`start IS NULL` |`pop_other>1038288` |`boolean=true` |2
-|`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other<1038288` |`name<='København'` |`pop_other=1038288` |242
-|`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`start<=TIMESTAMP('2022-04-16T10:13:19Z')` |`name<='København'` |`name<>'København'` |107
+|`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other<1038288` |`name\<='København'` |`pop_other=1038288` |242
+|`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`start\<=TIMESTAMP('2022-04-16T10:13:19Z')` |`name\<='København'` |`name<>'København'` |107
 |`boolean=true` |`name IS NOT NULL` |`boolean IS NULL` |`pop_other=1038288` |241
 |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other=1038288` |`pop_other<1038288` |`name<>'København'` |122
-|`pop_other<>1038288` |`start<=TIMESTAMP('2022-04-16T10:13:19Z')` |`start IS NOT NULL` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |243
+|`pop_other<>1038288` |`start\<=TIMESTAMP('2022-04-16T10:13:19Z')` |`start IS NOT NULL` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |243
 |`name<>'København'` |`pop_other<>1038288` |`pop_other IS NOT NULL` |`name IS NOT NULL` |243
 |`name='København'` |`pop_other<1038288` |`start IS NOT NULL` |`pop_other<>1038288` |3
 |`name<'København'` |`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |242
-|`boolean=true` |`pop_other<1038288` |`name IS NOT NULL` |`start<=TIMESTAMP('2022-04-16T10:13:19Z')` |243
-|`pop_other<=1038288` |`name<'København'` |`pop_other<1038288` |`pop_other<1038288` |243
-|`pop_other IS NULL` |`name<='København'` |`name='København'` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |242
+|`boolean=true` |`pop_other<1038288` |`name IS NOT NULL` |`start\<=TIMESTAMP('2022-04-16T10:13:19Z')` |243
+|`pop_other\<=1038288` |`name<'København'` |`pop_other<1038288` |`pop_other<1038288` |243
+|`pop_other IS NULL` |`name\<='København'` |`name='København'` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |242
 |`pop_other<1038288` |`name<>'København'` |`pop_other<>1038288` |`name<>'København'` |243
-|`start<=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other IS NULL` |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`name IS NOT NULL` |2
+|`start\<=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other IS NULL` |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`name IS NOT NULL` |2
 |`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`name='København'` |`boolean IS NULL` |`pop_other<>1038288` |241
-|`boolean=true` |`pop_other<=1038288` |`name<>'København'` |`pop_other IS NULL` |242
-|`name IS NOT NULL` |`pop_other<=1038288` |`start IS NOT NULL` |`boolean IS NOT NULL` |124
-|`pop_other<=1038288` |`pop_other<1038288` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other>1038288` |1
+|`boolean=true` |`pop_other\<=1038288` |`name<>'København'` |`pop_other IS NULL` |242
+|`name IS NOT NULL` |`pop_other\<=1038288` |`start IS NOT NULL` |`boolean IS NOT NULL` |124
+|`pop_other\<=1038288` |`pop_other<1038288` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other>1038288` |1
 |`start IS NOT NULL` |`boolean IS NOT NULL` |`name>='København'` |`pop_other IS NOT NULL` |137
 |`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`start IS NOT NULL` |`pop_other>1038288` |`pop_other<1038288` |122
-|`pop_other<=1038288` |`name<='København'` |`boolean IS NULL` |`start IS NOT NULL` |198
-|`name>='København'` |`name>='København'` |`name<='København'` |`name>='København'` |107
+|`pop_other\<=1038288` |`name\<='København'` |`boolean IS NULL` |`start IS NOT NULL` |198
+|`name>='København'` |`name>='København'` |`name\<='København'` |`name>='København'` |107
 |`boolean=true` |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean IS NOT NULL` |`name<'København'` |138
-|`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other IS NULL` |`pop_other<=1038288` |122
+|`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other IS NULL` |`pop_other\<=1038288` |122
 |`pop_other<1038288` |`name='København'` |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`name<'København'` |181
-|`pop_other<1038288` |`pop_other<=1038288` |`pop_other IS NULL` |`start IS NOT NULL` |121
+|`pop_other<1038288` |`pop_other\<=1038288` |`pop_other IS NULL` |`start IS NOT NULL` |121
 |`name>='København'` |`pop_other>=1038288` |`boolean=true` |`name IS NOT NULL` |79
 |`boolean IS NULL` |`name<>'København'` |`boolean IS NULL` |`pop_other IS NOT NULL` |240
-|`pop_other<1038288` |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`name>'København'` |`pop_other<=1038288` |241
-|`name<='København'` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`name<'København'` |`boolean IS NULL` |106
-|`pop_other IS NOT NULL` |`name<>'København'` |`pop_other<1038288` |`pop_other<=1038288` |121
+|`pop_other<1038288` |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`name>'København'` |`pop_other\<=1038288` |241
+|`name\<='København'` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`name<'København'` |`boolean IS NULL` |106
+|`pop_other IS NOT NULL` |`name<>'København'` |`pop_other<1038288` |`pop_other\<=1038288` |121
 |`name>='København'` |`start IS NOT NULL` |`name>='København'` |`name IS NOT NULL` |137
 |`pop_other<1038288` |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`name IS NULL` |`pop_other>=1038288` |120
 |`pop_other>=1038288` |`name>'København'` |`boolean IS NOT NULL` |`start IS NOT NULL` |184
-|`start IS NOT NULL` |`name<>'København'` |`name<='København'` |`name IS NULL` |241
+|`start IS NOT NULL` |`name<>'København'` |`name\<='København'` |`name IS NULL` |241
 |`name>='København'` |`pop_other<>1038288` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`name<>'København'` |2
-|`boolean IS NOT NULL` |`pop_other<=1038288` |`pop_other=1038288` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |241
+|`boolean IS NOT NULL` |`pop_other\<=1038288` |`pop_other=1038288` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |241
 |`name IS NOT NULL` |`start IS NOT NULL` |`start IS NOT NULL` |`name>='København'` |241
 |`pop_other=1038288` |`pop_other IS NOT NULL` |`start IS NOT NULL` |`name<>'København'` |2
-|`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`start IS NULL` |`pop_other>1038288` |`pop_other<=1038288` |122
+|`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`start IS NULL` |`pop_other>1038288` |`pop_other\<=1038288` |122
 |`name IS NULL` |`start IS NOT NULL` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`name IS NOT NULL` |1
 |`boolean IS NOT NULL` |`name='København'` |`boolean IS NOT NULL` |`name IS NOT NULL` |3
-|`pop_other<>1038288` |`pop_other<>1038288` |`pop_other=1038288` |`pop_other<=1038288` |1
+|`pop_other<>1038288` |`pop_other<>1038288` |`pop_other=1038288` |`pop_other\<=1038288` |1
 |`pop_other IS NULL` |`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean IS NOT NULL` |241
 |`start<TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean IS NULL` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`name<'København'` |138
 |`pop_other>1038288` |`pop_other<>1038288` |`start<>TIMESTAMP('2022-04-16T10:13:19Z')` |`name<>'København'` |2
 |`start>=TIMESTAMP('2022-04-16T10:13:19Z')` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other=1038288` |`name IS NOT NULL` |2
-|`pop_other<=1038288` |`start IS NOT NULL` |`start<=TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean IS NOT NULL` |242
+|`pop_other\<=1038288` |`start IS NOT NULL` |`start\<=TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean IS NOT NULL` |242
 |`boolean=true` |`start>TIMESTAMP('2022-04-16T10:13:19Z')` |`pop_other<1038288` |`pop_other<>1038288` |122
 |`pop_other>=1038288` |`pop_other>1038288` |`boolean IS NULL` |`pop_other=1038288` |121
 |`name<'København'` |`pop_other>1038288` |`start=TIMESTAMP('2022-04-16T10:13:19Z')` |`boolean=true` |180


### PR DESCRIPTION
Fixes for ASCIIDoc turning <= into arrows in ATS Table 6.