### PR TITLE
Add MapServer to list of server implementations

### DIFF
--- a/implementations/servers/README.md
+++ b/implementations/servers/README.md
@@ -13,3 +13,4 @@ We welcome pull requests to update this page to add or update an entry for a ser
 - [QGIS Server](qgis.md)
 - [SDI Rhineland-Palatinate](sdirp.md)
 - [pg_featureserv](pg_featureserv.md)
+- [MapServer](mapserver.md)

--- a/implementations/servers/mapserver.md
+++ b/implementations/servers/mapserver.md
@@ -1,0 +1,15 @@
+# MapServer
+
+[MapServer](https://www.mapserver.org) added [OGC Features API](https://www.mapserver.org/ogc/ogc_api.html) Part 1 Core support in version 8.0. 
+OGC API - Features - Part 2: Coordinate Reference Systems by Reference will be part of the upcoming MapServer 8.2 release and has been [merged](https://github.com/MapServer/MapServer/pull/6893)
+into the main code branch.
+
+## Demo deployment
+
+Example requests:
+
+* All feature collections: ([JSON](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections?f=json)) ([HTML](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections?f=html))
+* Single feature collection: ([JSON](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries?f=json)) ([HTML](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries?f=html))
+* Feature collection items: ([JSON](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries/items?f=json)) ([HTML](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries/items?f=html))
+* Feature collection single item: ([JSON](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries/items/1159320625?f=json) ([HTML](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries/items/1159320625?f=html))
+* Feature collection: bbox query: ([JSON](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries/items?bbox=-152,42,-52,84&f=json)) ([HTML](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/countries/items?bbox=-152,42,-52,84&f=html))


### PR DESCRIPTION
OGC Features API part 1 was added to MapServer 8.0 released in 09/2022. 

For info MapServer has an OGC product page at https://www.ogc.org/resources/product-details/?pid=1083. 