### PR TITLE
Implementations: rename nls-fi to hakunapi

### DIFF
--- a/implementations/README.adoc
+++ b/implementations/README.adoc
@@ -58,7 +58,7 @@ The columns for each part list the conformance classes of the standard that are 
 | https://www.ogc.org/resource/products/details/?pid=1669[Link]
 |
 
-| link:servers/nlsfi.md[nls-fi]
+| link:servers/hakunapi.md[hakunapi]
 | `core`, `oas30`, `geojson`
 | `crs`
 | -

--- a/implementations/servers/hakunapi.md
+++ b/implementations/servers/hakunapi.md
@@ -1,6 +1,8 @@
-# nls-fi
+# hakunapi
 
-Topographical database of National Land Survey of Finland as an OGC API - Features with some 130 collections. Powered by a server called hakuna-wfs3, implemented in Java at the NLS-Finland. Currently supporting JSON/GeoJSON (and also MVT for /tiles). Pagination via primary keys, fully streaming approach.
+Sample service running hakunapi:
+
+Topographical database of National Land Survey of Finland as an OGC API - Features with some 130 collections. Powered by a server called hakunapi, implemented in Java at the NLS-Finland. Currently supporting JSON/GeoJSON (and also MVT for /tiles). Pagination via primary keys, fully streaming approach.
 
 The service requires an API key! You can create one by self registering at https://omatili.maanmittauslaitos.fi/?lang=en (requires valid email address). Use the API key as the username in HTTP Basic Auth (password is ignored) or as query parameter ('api-key') as in the examples below.
 
@@ -14,3 +16,7 @@ Example requests:
 * https://avoin-paikkatieto.maanmittauslaitos.fi/maastotiedot/features/v1/collections/tieviiva/items/11?api-key=<API_KEY>
 * First 1000 buildings inside 380000,6670000,390000,6680000,EPSG:3067
 * https://avoin-paikkatieto.maanmittauslaitos.fi/maastotiedot/features/v1/collections/rakennus/items?bbox=380000,6670000,390000,6680000&bbox-crs=http://www.opengis.net/def/crs/EPSG/0/3067&crs=http://www.opengis.net/def/crs/EPSG/0/3067&limit=1000&api-key=<API_KEY>
+
+More information about hakunapi:
+
+* [GitHub repository with source code and documentation](https://github.com/nlsfi/hakunapi)


### PR DESCRIPTION
The server implementation used by National Land Survey of Finland was published earlier this year as an open source project called hakunapi.