### PR TITLE
Implementations: rename nls-fi to hakunapi #2

### DIFF
--- a/implementations/servers/README.md
+++ b/implementations/servers/README.md
@@ -9,7 +9,7 @@ We welcome pull requests to update this page to add or update an entry for a ser
 - [GeoServer](geoserver.md)
 - [pygeoapi](pygeoapi.md)
 - [sofp Server](sofp.md)
-- [nls-fi](nlsfi.md)
+- [hakunapi](hakunapi.md)
 - [QGIS Server](qgis.md)
 - [SDI Rhineland-Palatinate](sdirp.md)
 - [pg_featureserv](pg_featureserv.md)


### PR DESCRIPTION
Completes #858 which unfortunately missed a spot in `implementations/servers/README.md`