### PR TITLE
Updates based on discussions at Oct 2023 Code Sprint

### DIFF
--- a/extensions/schemas/standard/clause_11_queryables.adoc
+++ b/extensions/schemas/standard/clause_11_queryables.adoc
@@ -40,12 +40,12 @@ In addition, a <<publisher-def,publisher>> may want to support <<queryable-def,q
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
 ^|A |A successful execution of the operation SHALL be reported as a response with a HTTP status code `200`.
 ^|B |For responses that use `application/schema+json` as the `Content-Type` of the response, the response SHALL conform to <<rc_schemas>>.
-^|C |No property SHALL be of type "object".
-^|D |The items of a property of type "array" SHALL either be strings or numbers.
-^|D |If `additionalProperties` is not included or has the default value `true`, any property name is valid in a filter expression on the collection that is evalutated by the Web API and the property reference SHALL evaluate to `null`, if the property does not exist for a resource.
+^|C |If `additionalProperties` is not included or has the default value `true`, any property name is valid in a filter expression on the collection that is evalutated by the Web API and the property reference SHALL evaluate to `null`, if the property does not exist for a resource.
 
 If `additionalProperties` is set to false, property references that are not explicitly declared in the queryables schema SHALL result in a 400 response.
 |===
+
+NOTE: Depending on the filter language, some properties can not be supported in filter expressions. For example, if the filter language does not support predicates on object-valued properties, using such properties in a filter expression will result in an error.
 
 [[example_11_1]]
 .Filtering on complex data structures

--- a/extensions/schemas/standard/clause_12_sortables.adoc
+++ b/extensions/schemas/standard/clause_12_sortables.adoc
@@ -46,3 +46,4 @@ In addition, a <<publisher-def,publisher>> may want to support <<sortable-def,so
 
 If `additionalProperties` is set to false, property references that are not explicitly declared in the sortables schema SHALL result in a 400 response.
 |===
+

--- a/extensions/schemas/standard/clause_13_profile_parameter.adoc
+++ b/extensions/schemas/standard/clause_13_profile_parameter.adoc
@@ -8,7 +8,6 @@ The Requirements Class "Profile query parameter" specifies additional provisons 
 |===
 ^|*Requirements Class* |http://www.opengis.net/spec/{standard}/{m_n}/req/{req-class} 
 |Target type |Web API
-|Dependency |<<rc_core-api-bblocks>>
 |===
 
 Some properties may be represented in multiple representations in the same format, depending on the intended use of the data. One example are references to another web resource (see the <<rc_profile-references>>).

--- a/extensions/schemas/standard/clause_14_profile_references.adoc
+++ b/extensions/schemas/standard/clause_14_profile_references.adoc
@@ -54,7 +54,7 @@ The examples in this Clause use the <<example_9_1,example road accident feature 
   },
   "properties": {
     "timeOfAccident": "2019-02-05T07:00:00Z",
-    "roadSegement": "5209062A5209047O",
+    "roadSegment": "5209062A5209047O",
     "distanceFromStart": 851.0
   },
   "links": [
@@ -93,7 +93,7 @@ The examples in this Clause use the <<example_9_1,example road accident feature 
   },
   "properties": {
     "timeOfAccident": "2019-02-05T07:00:00Z",
-    "roadSegement": "https://example.com/apis/roads/collections/roadsegments/items/5209062A5209047O",
+    "roadSegment": "https://example.com/apis/roads/collections/roadsegments/items/5209062A5209047O",
     "distanceFromStart": 851.0
   },
   "links": [
@@ -136,7 +136,7 @@ The feature includes a "roadSegment" property that is a reference to the road se
   },
   "properties": {
     "timeOfAccident": "2019-02-05T07:00:00Z",
-    "roadSegement": {
+    "roadSegment": {
         "href": "https://example.com/apis/roads/collections/roadsegments/items/5209062A5209047O",
         "title": "Road L333, Segment 5209062A5209047O, Hennef"
     },

--- a/extensions/schemas/standard/clause_3_references.adoc
+++ b/extensions/schemas/standard/clause_3_references.adoc
@@ -8,3 +8,5 @@ The following normative documents contain provisions that, through reference in 
 * [[OAFeat-1]] Open Geospatial Consortium (OGC). OGC 17-069r4: **OGC API - Features - Part 1: Core** [online]. Edited by C. Portele, P. Vretanos, C. Heazel. 2022 [viewed 2023-10-14]. Available at https://docs.ogc.org/is/17-069r4/17-069r4.html
 
 * [[ogc06_103r4]] Open Geospatial Consortium (OGC). OGC 06-103r4: **OpenGIS® Implementation Standard for Geographic information - Simple feature access - Part 1: Common architecture**. Edited by J. Herring. 2011. Available at http://portal.opengeospatial.org/files/?artifact_id=25355
+
+* [[ucum]] Regenstrief Institute, Inc. **The Unified Code for Units of Measure**. Edited by G. Schadow, .C J. McDonald. 2017. Available at https://ucum.org/ucum.

--- a/extensions/schemas/standard/clause_7_schemas.adoc
+++ b/extensions/schemas/standard/clause_7_schemas.adoc
@@ -99,15 +99,15 @@ CAUTION: The next version of JSON Schema will likely restrict the use of additio
 ^|C |Only one property in a schema SHALL have "x-ogc-role" with a value "id".
 |===
 
-For cases, where the properties of the data have to be ordered in some representations of the data, the sequence of the properties can be expressed using a keyword "x-ogc-property-index".
+For cases, where the properties of the data have to be ordered in some representations of the data, the sequence of the properties can be expressed using a keyword "x-ogc-property-seq".
 
 :req: property-index
 [#{req-class}_{req}]
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |The keyword "x-ogc-property-index" SHALL be used to declare a specific relative position of the property.
-^|B |The value of the keyword "x-ogc-role" SHALL be an integer representing the relative position in ascending order.
+^|A |The keyword "x-ogc-property-seq" SHALL be used to declare a specific relative position of the property.
+^|B |The value of the keyword "x-ogc-property-seq" SHALL be an integer representing the relative position in ascending order.
 ^|C |Each value of the keyword SHALL be unique for all members of a "properties" object in the JSON Schema.
 |===
 
@@ -123,6 +123,8 @@ In geospatial data, numeric property values often represent a measurement and ha
 ^|C |The value of the keyword "x-ogc-unit" SHALL be the case sensitive UCUM representation ("c/s") unless a different language / register for units is identified in keyword "x-ogc-unit-lang".
 ^|D |The value for UCUM, if explicitly declared as the language for units in keyword "x-ogc-unit-lang", SHALL be "UCUM". 
 |===
+
+Communities or other OGC Standards can specify additional values for other unit languages, e.g., the https://www.qudt.org/doc/DOC_VOCAB-UNITS.html[QUDT Units] or https://www.opengis.net/def/uom[units registered in the OGC Rainbow]. For each language it must be specified how units have to be represented in the "x-ogc-unit" value.
 
 === Example
 
@@ -143,57 +145,57 @@ The following example is the schema of a feature type that also includes additio
       "readOnly" : true,
       "x-ogc-role" : "id",
       "type" : "integer",
-      "x-ogc-property-index": 1
+      "x-ogc-property-seq": 1
     },
     "F_CODE" : {
       "title" : "Feature Type Code",
       "x-ogc-role" : "type",
       "enum" : [ "AK121", "AL012", "AL030", "AL130", "BH075" ],
       "type" : "string",
-      "x-ogc-property-index": 2
+      "x-ogc-property-seq": 2
     },
     "geometry" : {
       "x-ogc-role" : "primary-geometry",
       "format" : "geometry-point",
-      "x-ogc-property-index": 3
+      "x-ogc-property-seq": 3
     },
     "ZI001_SDV" : {
       "title" : "Last Change",
       "x-ogc-role" : "primary-instant",
       "format" : "date-time",
       "type" : "string",
-      "x-ogc-property-index": 4
+      "x-ogc-property-seq": 4
     },
     "UFI" : {
       "title" : "Unique Entity Identifier",
       "type" : "string",
-      "x-ogc-property-index": 5
+      "x-ogc-property-seq": 5
     },
     "ZI005_FNA" : {
       "title" : "Name",
       "type" : "string",
-      "x-ogc-property-index": 6
+      "x-ogc-property-seq": 6
     },
     "FCSUBTYPE" : {
       "title" : "Feature Subtype Code",
       "type" : "integer",
-      "x-ogc-property-index": 7
+      "x-ogc-property-seq": 7
     },
     "ZI037_REL" : {
       "title" : "Religious Designation",
       "enum" : [ -999999, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ],
       "type" : "integer",
-      "x-ogc-property-index": 8
+      "x-ogc-property-seq": 8
     },
     "ZI006_MEM" : {
       "title" : "Memorandum",
       "type" : "string",
-      "x-ogc-property-index": 9
+      "x-ogc-property-seq": 9
     },
     "ZI001_SDP" : {
       "title" : "Source Description",
       "type" : "string",
-      "x-ogc-property-index": 10
+      "x-ogc-property-seq": 10
     }
   }
 }

--- a/extensions/schemas/standard/clause_7_schemas.adoc
+++ b/extensions/schemas/standard/clause_7_schemas.adoc
@@ -2,7 +2,7 @@
 [#rc_{req-class}]
 == Requirements Class "Schemas"
 
-The Requirements Class "Schemas" specifies basic provisions for schemas of items in a collection of geospatial data, for example, features, and the representation of a schema in JSON Schema.
+The Requirements Class "Schemas" specifies basic provisions for schemas of items in a collection of geospatial data, for example, features, and the representation of a schema in JSON Schema. The schema represents a logical model, independent of the format in which the feature is encoded.
 
 [cols="2,7",width="90%"]
 |===
@@ -11,16 +11,7 @@ The Requirements Class "Schemas" specifies basic provisions for schemas of items
 |Dependency |<<json-schema,JSON Schema: A Media Type for Describing JSON Documents>>
 |Indirect Dependency |<<json-schema-validation,JSON Schema Validation: A Vocabulary for Structural Validation of JSON>>
 |Indirect Dependency |<<ogc06_103r4,Simple feature access - Part 1: Common architecture>>
-|===
-
-:req: logical-model
-[#{req-class}_{req}]
-=== Level of abstraction
-
-[width="90%",cols="2,7a"]
-|===
-^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |The schema SHALL be a logical model.
+|Indirect Dependency |<<ucum,The Unified Code for Units of Measure>>
 |===
 
 [#schema-representation]
@@ -34,7 +25,7 @@ The Requirements Class "Schemas" specifies basic provisions for schemas of items
 ^|A |The schema SHALL be a valid JSON Schema.
 ^|B |The schema SHALL have the following characteristics:
 
-* "$schema" is "\https://json-schema.org/draft/2020-12/schema" or "\https://json-schema.org/draft/2019-09/schema";
+* "$schema" is "\https://json-schema.org/draft/2020-12/schema";
 * "$id" is a HTTP(S) URI without query parameters that returns the schema, if requested with the header "Accept: application/schema+json"; and 
 * "type" is "object".
 |===
@@ -70,6 +61,8 @@ The following recommendations are intended to simplify parsing a schema and to h
 ^|G |For numeric properties, "multipleOf", "minimum", "exclusiveMinimum", "maximum", "exclusiveMaximum" SHOULD be provided, where applicable.
 ^|H |For integer properties that represent enumerated values, "enum" SHOULD be provided.
 ^|I |Required properties SHOULD be included in "required".
+^|J |The JSON Schema keywords SHOULD be constrainted to the those mentioned in this recommendation and requirement `/req/{req-class}/properties`.
+
 |===
 
 [#additional-keywords]
@@ -106,6 +99,31 @@ CAUTION: The next version of JSON Schema will likely restrict the use of additio
 ^|C |Only one property in a schema SHALL have "x-ogc-role" with a value "id".
 |===
 
+For cases, where the properties of the data have to be ordered in some representations of the data, the sequence of the properties can be expressed using a keyword "x-ogc-property-index".
+
+:req: property-index
+[#{req-class}_{req}]
+[width="90%",cols="2,7a"]
+|===
+^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
+^|A |The keyword "x-ogc-property-index" SHALL be used to declare a specific relative position of the property.
+^|B |The value of the keyword "x-ogc-role" SHALL be an integer representing the relative position in ascending order.
+^|C |Each value of the keyword SHALL be unique for all members of a "properties" object in the JSON Schema.
+|===
+
+In geospatial data, numeric property values often represent a measurement and have a unit of measure. For fixed units, this can be expressed in the schema using a keyword "x-ogc-unit".
+
+:req: unit
+[#{req-class}_{req}]
+[width="90%",cols="2,7a"]
+|===
+^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
+^|A |The keyword "x-ogc-unit" SHALL be used to declare the unit of measure of the property.
+^|B |The value of the keyword "x-ogc-unit" SHALL be a string representing the unit of measure.
+^|C |The value of the keyword "x-ogc-unit" SHALL be the case sensitive UCUM representation ("c/s") unless a different language / register for units is identified in keyword "x-ogc-unit-lang".
+^|D |The value for UCUM, if explicitly declared as the language for units in keyword "x-ogc-unit-lang", SHALL be "UCUM". 
+|===
+
 === Example
 
 The following example is the schema of a feature type that also includes additional keywords that apply to feature data (specified in the next Clause).
@@ -121,51 +139,61 @@ The following example is the schema of a feature type that also includes additio
   "type" : "object",
   "title" : "Cultural (Points)",
   "properties" : {
-    "id" : {
+    "FID" : {
       "readOnly" : true,
       "x-ogc-role" : "id",
-      "type" : "integer"
+      "type" : "integer",
+      "x-ogc-property-index": 1
     },
     "F_CODE" : {
       "title" : "Feature Type Code",
       "x-ogc-role" : "type",
       "enum" : [ "AK121", "AL012", "AL030", "AL130", "BH075" ],
-      "type" : "string"
+      "type" : "string",
+      "x-ogc-property-index": 2
     },
     "geometry" : {
       "x-ogc-role" : "primary-geometry",
-      "format" : "geometry-point"
+      "format" : "geometry-point",
+      "x-ogc-property-index": 3
     },
     "ZI001_SDV" : {
       "title" : "Last Change",
       "x-ogc-role" : "primary-instant",
       "format" : "date-time",
-      "type" : "string"
+      "type" : "string",
+      "x-ogc-property-index": 4
     },
     "UFI" : {
       "title" : "Unique Entity Identifier",
-      "type" : "string"
+      "type" : "string",
+      "x-ogc-property-index": 5
     },
     "ZI005_FNA" : {
       "title" : "Name",
-      "type" : "string"
+      "type" : "string",
+      "x-ogc-property-index": 6
     },
     "FCSUBTYPE" : {
       "title" : "Feature Subtype Code",
-      "type" : "integer"
+      "type" : "integer",
+      "x-ogc-property-index": 7
     },
     "ZI037_REL" : {
       "title" : "Religious Designation",
       "enum" : [ -999999, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ],
-      "type" : "integer"
+      "type" : "integer",
+      "x-ogc-property-index": 8
     },
     "ZI006_MEM" : {
       "title" : "Memorandum",
-      "type" : "string"
+      "type" : "string",
+      "x-ogc-property-index": 9
     },
     "ZI001_SDP" : {
       "title" : "Source Description",
-      "type" : "string"
+      "type" : "string",
+      "x-ogc-property-index": 10
     }
   }
 }

--- a/extensions/schemas/standard/clause_8_core_roles_for_features.adoc
+++ b/extensions/schemas/standard/clause_8_core_roles_for_features.adoc
@@ -31,7 +31,7 @@ If the features have multiple spatial properties, the role "primary-geometry" ca
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
 ^|A |A property with "x-ogc-role" set to "primary-geometry" SHALL be a spatial property.
 ^|B |At most one property in a schema SHALL have "x-ogc-role" with a value "primary-geometry".
-^|C |If the schema has only one spatial property, the property SHALL be the primary geometry also if the property is not explicitly tagged with the role "primary-geometry".
+^|C |If the schema has only one spatial property, the property SHALL be the primary geometry even if the property is not explicitly tagged with the role "primary-geometry".
 |===
 
 NOTE: Since only a single property can be tagged in the schema as the primary geometry, varying primary geometries at different zoom levels are currently not supported. This would require the capability to assign the role depening on the zoom level.
@@ -47,7 +47,7 @@ If the features have multiple temporal properties, the roles "primary-instant", 
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
 ^|A |A property with "x-ogc-role" set to "primary-instant" SHALL be a temporal property.
 ^|B |At most one property in a schema SHALL have "x-ogc-role" with a value "primary-instant".
-^|C |If the schema has only one temporal property, the property SHALL be the primary temporal information also if the property is not explicitly tagged with the role "primary-instant".
+^|C |If the schema has only one temporal property, the property SHALL be the primary temporal information even if the property is not explicitly tagged with the role "primary-instant".
 |===
 
 :req: role-primary-interval-start
@@ -76,6 +76,8 @@ If the features have multiple temporal properties, the roles "primary-instant", 
 ^|A |If a schema has a property with role "primary-instant", the schema SHALL NOT have properties with role "primary-interval-start" or "primary-interval-end".
 ^|B |If a schema has properties with both roles "primary-interval-start" and "primary-interval-end", both properties SHALL have the same temporal granularity ("date" or "date-time").
 |===
+
+NOTE: Consider to add a role "primary-interval" with a proper representation of an interval, e.g., the interval representation in JSON-FG (an array with two dates or timestamps).
 
 === Feature type
 
@@ -121,7 +123,9 @@ The following example is the schema of a feature type with the roles "id", "prim
     "area_km2" : {
       "title" : "Area (km²)",
       "description" : "The polygon area in square kilometers, computed using an Eckert VI projection.",
-      "type" : "number"
+      "type" : "number",
+      "x-ogc-unit": "km2"
+
     },
     "capname" : {
       "title" : "Country capital",

--- a/extensions/schemas/standard/clause_9_feature_references.adoc
+++ b/extensions/schemas/standard/clause_9_feature_references.adoc
@@ -54,7 +54,7 @@ This is the schema of a raod accident feature type. The "roadSegment" property i
       "format": "date-time",
       "type": "string"
     },
-    "roadSegement": {
+    "roadSegment": {
       "title": "Road segment",
       "description": "Road segment on which the accident occured, identified by its 16-character code (8 characters for the start and end node).",
       "x-ogc-role": "reference",
@@ -65,7 +65,8 @@ This is the schema of a raod accident feature type. The "roadSegment" property i
       "title": "Distance from start [m]",
       "description": "Distance from the start node of the road segment. The unit is meter.",
       "minimum": 0.0,
-      "type": "number"
+      "type": "number",
+      "x-ogc-unit": "m"
     },
     "geometry": {
       "x-ogc-role": "primary-geometry",


### PR DESCRIPTION
List of changes:

- Change `/req/schemas/logical-model` into informative text (not testable).
- Add a "x-ogc-property-index" keyword in "Schemas" to express the sequence of the properties (in a coverage or for a feature encoding that is ordered, e.g. GML).
- Only reference JSON Schema 2020-12 (latest version).
- In `/rec/schemas/properties` clarify that no other keywords should be used.
- Add "x-ogc-unit" as a keyword in "Schemas" to declare the unit of measure of a numeric property.
- Add "x-ogc-unit" in examples.
- Additional ones, like the URI of a definition should be added in an extension, if needed.
- Do not use "id" as the property name of an "id" property in the examples.
- Improve the wording in some normative statements.
- Consider to add a "primary-interval" role with a proper interval representation (array of two instants).
- Fix typo (roadSegement -> roadSegment)
- Remove broken dependency in Clause 13.
- We should not restrict the data types of queryables, what is supported will depend on the filter language.  Add a note that filter languages may not support data types.
