### PR TITLE
adjust link templates

### DIFF
--- a/core/openapi/ogcapi-features-1.yaml
+++ b/core/openapi/ogcapi-features-1.yaml
@@ -154,6 +154,10 @@ components:
             - href: http://example.com/concepts/buildings.html
               rel: describedby
               type: text/html
+        linkTemplates:
+          type: array
+          items:
+            $ref: "#/components/schemas/linkTemplate"
         extent:
           $ref: "#/components/schemas/extent"
         itemType:
@@ -442,6 +446,25 @@ components:
           example: Trierer Strasse 70, 53115 Bonn
         length:
           type: integer
+    linkTemplate:
+      type: object
+      required:
+        - uriTemplate
+        - rel
+      properties:
+        uriTemplate:
+          type: string
+          example: https://data.example.org/collections/buildings/items/{featureId}
+        rel:
+          type: string
+        title:
+          type: string
+          example: Link template for building features
+        type:
+          type: string
+          example: application/geo+json
+        varBase:
+          type: string
     multilinestringGeoJSON:
       type: object
       required:

--- a/core/openapi/schemas/collection.yaml
+++ b/core/openapi/schemas/collection.yaml
@@ -25,6 +25,10 @@ properties:
       - href: http://example.com/concepts/buildings.html
         rel: describedby
         type: text/html
+  linkTemplates:
+    type: array
+    items:
+      $ref: linkTemplate.yaml
   extent:
     $ref: extent.yaml
   itemType:

--- a/core/openapi/schemas/linkTemplate.yaml
+++ b/core/openapi/schemas/linkTemplate.yaml
@@ -1,0 +1,18 @@
+type: object
+required:
+  - uriTemplate
+  - rel
+properties:
+  uriTemplate:
+    type: string
+    example: https://data.example.org/collections/buildings/items/{featureId}
+  rel:
+    type: string
+  title:
+    type: string
+    example: Link template for building features
+  type:
+    type: string
+    example: application/geo+json
+  varBase:
+    type: string

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -657,15 +657,17 @@ Reference system information is not provided as the service provides geometries 
         { "href": "https://data.example.org/collections/buildings/items",
           "rel": "items", "type": "application/geo+json",
           "title": "Buildings" },
-        { "href": "https://data.example.org/collections/buildings/items/{featureId}",
-          "rel": "item", "title": "Link template for building features", 
-          "templated": true },  
         { "href": "https://creativecommons.org/publicdomain/zero/1.0/",
           "rel": "license", "type": "text/html",
           "title": "CC0-1.0" },
         { "href": "https://creativecommons.org/publicdomain/zero/1.0/rdf",
           "rel": "license", "type": "application/rdf+xml",
           "title": "CC0-1.0" }
+      ],
+      "linkTemplates": [
+        { "uriTemplate": "https://data.example.org/collections/buildings/items/{featureId}",
+          "rel": "item", "title": "Link template for building features", 
+          "varBase": "https://data.example.org/collections/buildings/var-base/" }
       ]
     }
   ]
@@ -690,7 +692,7 @@ link: <https://data.example.org/collections/buildings>; anchor="#/collections/0"
 link: <https://data.example.org/collections/buildings/items>; anchor="#/collections/0"; rel="items"; type="application/geo+json"; title="Buildings"
 link: <https://creativecommons.org/publicdomain/zero/1.0/>; anchor="#/collections/0"; rel="license"; type="text/html"; title="CC0-1.0"
 link: <https://creativecommons.org/publicdomain/zero/1.0/rdf>; anchor="#/collections/0"; rel="license"; type="application/rdf+xml"; title="CC0-1.0"
-link-template: <https://data.example.org/collections/buildings/items/{featureId}>; anchor="#/collections/0"; rel="item"; title="Link template for buildung features"
+link-template: <https://data.example.org/collections/buildings/items/{featureId}>; anchor="#/collections/0"; rel="item"; title="Link template for buildung features"; var-base="https://data.example.org/collections/buildings/var-base/"
 vary: Accept,Accept-Language,Accept-Encoding
 content-length: 6178
 ----

--- a/core/standard/recomendations/core/REC_fc-md-item-link-templates.adoc
+++ b/core/standard/recomendations/core/REC_fc-md-item-link-templates.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/fc-md-item-link-templates*
-^|A |For each feature collection included in the response, the `links` property of the collection SHOULD include a link template to the URI of the features (relation: `item`). 
-^|B |The link template SHALL be encoded as a Link object with a property `templated` set to `true` and the URI template in `href`.
+^|A |For each feature collection included in the response, the `linkTemplates` property of the collection SHOULD include a link template to the URI of the features (relation: `item`). 
+^|B |The link template SHALL be encoded as a LinkTemplate object with the URI template in `uriTemplate`.
 ^|C |If links are included in `Link` HTTP headers of the response, the link templates SHOULD also be included in `Link-Template` HTTP headers according to the https://datatracker.ietf.org/doc/draft-ietf-httpapi-link-template/[draft "The Link-Template HTTP Header Field" specification].
 |===


### PR DESCRIPTION
This PR updates templated links based on Architecture DWG / OAB motion.

Note that the current PR in OGC API Records uses "href", but a URI template is not a "hypertext reference", it is a URI template. This PR therefore uses "uriTemplate" instead.

closes #844