### PR TITLE
Fix isNull in CQL2 specs.

### DIFF
--- a/cql2/standard/schema/cql2.json
+++ b/cql2/standard/schema/cql2.json
@@ -22,7 +22,7 @@
       "$ref": "#/$defs/arrayPredicate"
     },
     {
-       "$ref": "#/$defs/functionRef"
+      "$ref": "#/$defs/functionRef"
     },
     {
       "type": "boolean"
@@ -175,10 +175,10 @@
           "properties": {
             "op": { "type": "string", "enum": [ "casei" ] },
             "args": {
-               "type": "array",
-               "items": { "$ref": "#/$defs/patternExpression" },
-               "minItems": 1,
-               "maxItems": 1
+              "type": "array",
+              "items": { "$ref": "#/$defs/patternExpression" },
+              "minItems": 1,
+              "maxItems": 1
             }
           }
         },
@@ -188,10 +188,10 @@
           "properties": {
             "op": { "type": "string", "enum": [ "accenti" ] },
             "args": {
-               "type": "array",
-               "items": { "$ref": "#/$defs/patternExpression" },
-               "minItems": 1,
-               "maxItems": 1
+              "type": "array",
+              "items": { "$ref": "#/$defs/patternExpression" },
+              "minItems": 1,
+              "maxItems": 1
             }
           }
         },
@@ -284,23 +284,28 @@
       }
     },
     "isNullOperand": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/characterExpression"
-        },
-        {
-          "$ref": "#/$defs/numericExpression"
-        },
-        {
-          "$dynamicRef": "#cql2expression"
-        },
-        {
-          "$ref": "#/$defs/geomExpression"
-        },
-        {
-          "$ref": "#/$defs/temporalExpression"
-        }
-      ]
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/characterExpression"
+          },
+          {
+            "$ref": "#/$defs/numericExpression"
+          },
+          {
+            "$dynamicRef": "#cql2expression"
+          },
+          {
+            "$ref": "#/$defs/geomExpression"
+          },
+          {
+            "$ref": "#/$defs/temporalExpression"
+          }
+        ]
+      }
     },
 
     "spatialPredicate": {
@@ -511,10 +516,10 @@
       "properties": {
         "op": { "type": "string", "enum": [ "casei" ] },
         "args": {
-           "type": "array",
-           "items": { "$ref": "#/$defs/characterExpression" },
-           "minItems": 1,
-           "maxItems": 1
+          "type": "array",
+          "items": { "$ref": "#/$defs/characterExpression" },
+          "minItems": 1,
+          "maxItems": 1
         }
       }
     },
@@ -525,10 +530,10 @@
       "properties": {
         "op": { "type": "string", "enum": [ "accenti" ] },
         "args": {
-           "type": "array",
-           "items": { "$ref": "#/$defs/characterExpression" },
-           "minItems": 1,
-           "maxItems": 1
+          "type": "array",
+          "items": { "$ref": "#/$defs/characterExpression" },
+          "minItems": 1,
+          "maxItems": 1
         }
       }
     },

--- a/cql2/standard/schema/cql2.yml
+++ b/cql2/standard/schema/cql2.yml
@@ -191,12 +191,16 @@ components:
         args:
           $ref: '#/components/schemas/isNullOperand'
     isNullOperand:
-      oneOf:
-        - $ref: '#/components/schemas/characterExpression'
-        - $ref: '#/components/schemas/numericExpression'
-        - $ref: '#/components/schemas/temporalExpression'
-        - $ref: '#/components/schemas/booleanExpression'
-        - $ref: '#/components/schemas/geomExpression'
+      type: array
+      minItems: 1
+      maxItems: 1
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/characterExpression'
+          - $ref: '#/components/schemas/numericExpression'
+          - $ref: '#/components/schemas/temporalExpression'
+          - $ref: '#/components/schemas/booleanExpression'
+          - $ref: '#/components/schemas/geomExpression'
     spatialPredicate:
       type: object
       required:

--- a/cql2/standard/schema/examples/json/example41.json
+++ b/cql2/standard/schema/examples/json/example41.json
@@ -1,4 +1,4 @@
 {
   "op": "isNull",
-  "args": { "property": "value" }
+  "args": [ { "property": "value" } ]
 }

--- a/cql2/standard/schema/examples/json/example42.json
+++ b/cql2/standard/schema/examples/json/example42.json
@@ -3,7 +3,7 @@
   "args": [
     {
       "op": "isNull",
-      "args": { "property": "value" }
+      "args": [ { "property": "value" } ]
     }
   ]
 }

--- a/cql2/standard/schema/examples/json/example44.json
+++ b/cql2/standard/schema/examples/json/example44.json
@@ -3,7 +3,7 @@
   "args": [
     {
       "op": "isNull",
-      "args": { "property": "value" }
+      "args": [ { "property": "value" } ]
     },
     {
       "op": "between",


### PR DESCRIPTION
Fixes: #882 @pvretano 

VSCode formatter removed some extra spaces in the JSON too. Was only a few, so I figured it didn't clog up to the diff too much.
It also wanted to switch all the `'` to `"` in the yaml, but that ends up a big diff and I didn't want to make things too messy. 