### PR TITLE
deleting a resource that does not exist should return 404

### DIFF
--- a/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
@@ -249,15 +249,11 @@ include::requirements/create-replace-delete/delete/REQ_response.adoc[]
 If the server will process the update request later, it will return a `202`. In this
 case, the processing can succeed or fail, without further notification to the client.
 
-Note that if no resource with the identifier exists in the collection, the server can respond 
-with a success status (`200` or `204`) or with a not-found exception (`404`).
-
-NOTE: See https://github.com/opengeospatial/ogcapi-features/issues/328[Issue 328]. 
-Should it be up to the server whether it responds with a 204 or a 404, if no feature exists?
-
 ==== Exceptions
 
 See <<http_status_codes,HTTP status codes>>.
+
+include::recommendations/create-replace-delete/delete/REC_no-feature.adoc[]
 
 ==== Example
 

--- a/extensions/transactions/create-replace-update-delete/standard/recommendations/create-replace-delete/delete/REC_no-feature.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/recommendations/create-replace-delete/delete/REC_no-feature.adoc
@@ -1,0 +1,6 @@
+[[rec_delete_no-feature]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/delete/no-feature*
+^|A |If no resource with the identifier exists in the collection, the response SHOULD be `404` (not found).
+|===


### PR DESCRIPTION
In the discussion at the code sprint we agreed that a 404 would in general be the appropriate response, but since there may also be situation where an API provider may want to return a 204, we make this a recommendation, not a requirement.

Closes #328

