### PR TITLE
Validating BNF and add disclaimer.

### DIFF
--- a/cql2/standard/annex_bnf.adoc
+++ b/cql2/standard/annex_bnf.adoc
@@ -5,7 +5,19 @@
 [reftext="CQL2 BNF"]
 == CQL2 BNF (Normative)
 
+[NOTE]
+====
+Because there are many variations of EBNF, this standard has focused on verifying that this grammar validates using the following online validator:
+
+`https://www.icosaedro.it/bnf_chk/bnf_chk-on-line.html`
+
+If other tools are used (e.g. ANTLR), the grammar will likely need to be adapted to suite the target implementation context.
+====
+
 [source,abnf]
 ----
 include::schema/cql2.bnf[]
 ----
+
+
+

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -15,7 +15,15 @@
 # Predicates include scalar or comparison predicates, spatial predicates or
 # temporal predicates.
 #
-# NOTE: Validated using: https://www.icosaedro.it/bnf_chk/bnf_chk-on-line.html
+# *** DISCLAIMER: ***
+# Because there are many variations of EBNF, this standard has focused
+# on verifying that this grammar validates using the following online
+# validator:
+#
+# https://www.icosaedro.it/bnf_chk/bnf_chk-on-line.html
+#
+# If other tools are used (e.g. ANTLR), the grammar will likely need to be
+# adapted to suite the target implementation context.
 #=============================================================================#
 booleanExpression = booleanTerm [ {"OR" booleanTerm} ];
 
@@ -372,7 +380,7 @@ characterLiteral = "'" [ {character} ] "'";
 
 character = alpha | digit | whitespace | escapeQuote;
 
-escapeQuote = "''" | "\'";
+escapeQuote = "''" | "\\'";
 
 # character & digit productions copied from:
 # https://www.w3.org/TR/REC-xml/#charsets


### PR DESCRIPTION
Closes #854 

I validated the BNF using https://www.icosaedro.it/bnf_chk/bnf_chk-on-line.html.  

There was one small error that I fixed  but otherwise the validator was happy.  I aslo added a disclaimer in the BNF annex and in the BNF file iteself basically saying that we validated using the aforementioned validator and if you use another tool (e.g. ANTLR) you will have to adjust the BNF to suite.