### PR TITLE
add "x-ogc-definition" to the list of schema keywords

### DIFF
--- a/extensions/schemas/standard/clause_7_schemas.adoc
+++ b/extensions/schemas/standard/clause_7_schemas.adoc
@@ -126,6 +126,17 @@ In geospatial data, numeric property values often represent a measurement and ha
 
 Communities or other OGC Standards can specify additional values for other unit languages, e.g., the https://www.qudt.org/doc/DOC_VOCAB-UNITS.html[QUDT Units] or https://www.opengis.net/def/uom[units registered in the OGC Rainbow]. For each language it must be specified how units have to be represented in the "x-ogc-unit" value.
 
+NOTE: UCUM provides a language to define units while QUDT provides a units vocabulary. The term "language" is used as it is the broader term.
+
+:req: definition
+[#{req-class}_{req}]
+[width="90%",cols="2,7a"]
+|===
+^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
+^|A |The keyword "x-ogc-definition" SHALL be used to identify the semantic definition for the property.
+^|B |The value of the keyword "x-ogc-definition" SHALL be a URI.
+|===
+
 === Example
 
 The following example is the schema of a feature type that also includes additional keywords that apply to feature data (specified in the next Clause).


### PR DESCRIPTION
Closes #838.

This PR also adds a comment on "x-ogc-unit-lang" to clarify that while UCUM specifies a language, other sources like QUDT provide a (finite) vocabulary.

The other keywords do not seem to be general enough and should be specified in resource-specific standards.
