### PR TITLE
Fix CQL2 JSON Schema and some examples

### DIFF
--- a/cql2/standard/schema/cql2.json
+++ b/cql2/standard/schema/cql2.json
@@ -1,156 +1,80 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$dynamicAnchor": "cql2expression",
-  "type": "object",
   "oneOf": [
-    {
-      "$ref": "#/$defs/andOrExpression"
-    },
-    {
-      "$ref": "#/$defs/notExpression"
-    },
-    {
-      "$ref": "#/$defs/comparisonPredicate"
-    },
-    {
-      "$ref": "#/$defs/spatialPredicate"
-    },
-    {
-      "$ref": "#/$defs/temporalPredicate"
-    },
-    {
-      "$ref": "#/$defs/arrayPredicate"
-    },
-    {
-      "$ref": "#/$defs/functionRef"
-    },
-    {
-      "type": "boolean"
-    }
+    {"$ref": "#/$defs/andOrExpression"    },
+    {"$ref": "#/$defs/notExpression"      },
+    {"$ref": "#/$defs/comparisonPredicate"},
+    {"$ref": "#/$defs/spatialPredicate"   },
+    {"$ref": "#/$defs/temporalPredicate"  },
+    {"$ref": "#/$defs/arrayPredicate"     },
+    {"$ref": "#/$defs/functionRef"        },
+    {"type": "boolean"                    }
   ],
   "$defs": {
-
     "andOrExpression": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": {
-          "type": "string",
-          "enum": [ "and", "or" ]
-        },
+        "op": { "type": "string", "enum": ["and", "or"] },
         "args": {
           "type": "array",
           "minItems": 2,
-          "items": {
-            "$dynamicRef": "#cql2expression"
-          }
+          "items": {"$dynamicRef": "#cql2expression"}
         }
       }
     },
-
     "notExpression": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": {
-          "type": "string",
-          "enum": [ "not" ]
-        },
+        "op": { "type": "string", "enum": ["not"] },
         "args": {
           "type": "array",
           "minItems": 1,
           "maxItems": 1,
-          "items": {
-            "$dynamicRef": "#cql2expression"
-          }
+          "items": {"$dynamicRef": "#cql2expression"}
         }
       }
     },
-
     "comparisonPredicate": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/binaryComparisonPredicate"
-        },
-        {
-          "$ref": "#/$defs/isLikePredicate"
-        },
-        {
-          "$ref": "#/$defs/isBetweenPredicate"
-        },
-        {
-          "$ref": "#/$defs/isInListPredicate"
-        },
-        {
-          "$ref": "#/$defs/isNullPredicate"
-        }
+        {"$ref": "#/$defs/binaryComparisonPredicate"},
+        {"$ref": "#/$defs/isLikePredicate"          },
+        {"$ref": "#/$defs/isBetweenPredicate"       },
+        {"$ref": "#/$defs/isInListPredicate"        },
+        {"$ref": "#/$defs/isNullPredicate"          }
       ]
     },
-
     "binaryComparisonPredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": {
-          "type": "string",
-          "enum": [ "=", "<>", "<", ">", "<=", ">=" ]
-        },
-        "args": {
-          "$ref": "#/$defs/scalarOperands"
-        }
+        "op": { "type": "string", "enum": ["=", "<>", "<", ">", "<=", ">="] },
+        "args": {"$ref": "#/$defs/scalarOperands"}
       }
     },
     "scalarOperands": {
       "type": "array",
       "minItems": 2,
       "maxItems": 2,
-      "items": {
-        "$ref": "#/$defs/scalarExpression"
-      }
+      "items": {"$ref": "#/$defs/scalarExpression"}
     },
-
     "scalarExpression": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/characterExpression"
-        },
-        {
-          "$ref": "#/$defs/numericExpression"
-        },
-        {
-          "$dynamicRef": "#cql2expression"
-        },
-        {
-          "$ref": "#/$defs/temporalInstantExpression"
-        }
+        {"$ref": "#/$defs/characterExpression"},
+        {"$ref": "#/$defs/numericExpression"}  ,
+        {"$dynamicRef": "#cql2expression"}     ,
+        {"$ref": "#/$defs/instantInstance"}    ,
+        {"$ref": "#/$defs/propertyRef"}
       ]
     },
-
-    "temporalInstantExpression": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/instantInstance"
-        },
-        {
-          "$ref": "#/$defs/propertyRef"
-        },
-        {
-          "$ref": "#/$defs/functionRef"
-        }
-      ]
-    },
-
     "isLikePredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": {
-          "type": "string",
-          "enum": [ "like" ]
-        },
-        "args": {
-          "$ref": "#/$defs/isLikeOperands"
-        }
+        "op"  : { "type": "string", "enum": ["like"] },
+        "args": {"$ref": "#/$defs/isLikeOperands"}
       }
     },
     "isLikeOperands": {
@@ -159,24 +83,25 @@
       "maxItems": 2,
       "prefixItems": [
         {
-          "$ref": "#/$defs/characterExpression"
+          "oneOf": [
+            {"$ref": "#/$defs/characterExpression"},
+            {"$ref": "#/$defs/propertyRef"        },
+            {"$ref": "#/$defs/functionRef"        }
+          ]
         },
-        {
-          "$ref": "#/$defs/patternExpression"
-        }
+        {"$ref": "#/$defs/patternExpression"}
       ]
     },
-
     "patternExpression": {
       "oneOf": [
         {
           "type": "object",
-          "required": [ "op", "args" ],
+          "required": ["op", "args"],
           "properties": {
-            "op": { "type": "string", "enum": [ "casei" ] },
+            "op": { "type": "string", "enum": ["casei"] },
             "args": {
               "type": "array",
-              "items": { "$ref": "#/$defs/patternExpression" },
+              "items": {"$ref": "#/$defs/patternExpression"},
               "minItems": 1,
               "maxItems": 1
             }
@@ -184,34 +109,26 @@
         },
         {
           "type": "object",
-          "required": [ "op", "args" ],
+          "required": ["op", "args"],
           "properties": {
-            "op": { "type": "string", "enum": [ "accenti" ] },
+            "op": { "type": "string", "enum": ["accenti"] },
             "args": {
               "type": "array",
-              "items": { "$ref": "#/$defs/patternExpression" },
+              "items": {"$ref": "#/$defs/patternExpression"},
               "minItems": 1,
               "maxItems": 1
             }
           }
         },
-        {
-          "type": "string"
-        }
+        {"type": "string"}
       ]
     },
-
     "isBetweenPredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": {
-          "type": "string",
-          "enum": [ "between" ]
-        },
-        "args": {
-          "$ref": "#/$defs/isBetweenOperands"
-        }
+        "op"  : { "type": "string", "enum": ["between"] },
+        "args": {"$ref": "#/$defs/isBetweenOperands"}
       }
     },
     "isBetweenOperands": {
@@ -219,38 +136,22 @@
       "minItems": 3,
       "maxItems": 3,
       "items": {
-        "$ref": "#/$defs/numericExpression"
-      },
-      "additionalItems": false
+        "oneOf": [
+          {"$ref": "#/$defs/numericExpression"},
+          {"$ref": "#/$defs/propertyRef"      },
+          {"$ref": "#/$defs/functionRef"      }
+        ]
+      }
     },
     "numericExpression": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/arithmeticExpression"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/$defs/propertyRef"
-        },
-        {
-          "$ref": "#/$defs/functionRef"
-        }
-      ]
+      "oneOf": [ {"$ref": "#/$defs/arithmeticExpression"}, {"type": "number"} ]
     },
-
     "isInListPredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": {
-          "type": "string",
-          "enum": [ "in" ]
-        },
-        "args": {
-          "$ref": "#/$defs/inListOperands"
-        }
+        "op"  : { "type": "string", "enum": ["in"] },
+        "args": {"$ref": "#/$defs/inListOperands"}
       }
     },
     "inListOperands": {
@@ -258,29 +159,16 @@
       "minItems": 2,
       "maxItems": 2,
       "prefixItems": [
-        {
-          "$ref": "#/$defs/scalarExpression"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/scalarExpression"
-          }
-        }
+        {"$ref": "#/$defs/scalarExpression"}                              ,
+        { "type": "array", "items": {"$ref": "#/$defs/scalarExpression"} }
       ]
     },
-
     "isNullPredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": {
-          "type": "string",
-          "enum": [ "isNull" ]
-        },
-        "args": {
-          "$ref": "#/$defs/isNullOperand"
-        }
+        "op"  : { "type": "string", "enum": ["isNull"] },
+        "args": {"$ref": "#/$defs/isNullOperand"}
       }
     },
     "isNullOperand": {
@@ -289,45 +177,27 @@
       "maxItems": 1,
       "items": {
         "oneOf": [
-          {
-            "$ref": "#/$defs/characterExpression"
-          },
-          {
-            "$ref": "#/$defs/numericExpression"
-          },
-          {
-            "$dynamicRef": "#cql2expression"
-          },
-          {
-            "$ref": "#/$defs/geomExpression"
-          },
-          {
-            "$ref": "#/$defs/temporalExpression"
-          }
+          {"$ref": "#/$defs/characterExpression"},
+          {"$ref": "#/$defs/numericExpression"}  ,
+          {"$dynamicRef": "#cql2expression"}     ,
+          {"$ref": "#/$defs/spatialInstance"}    ,
+          {"$ref": "#/$defs/temporalInstance"}   ,
+          {"$ref": "#/$defs/propertyRef"}
         ]
       }
     },
-
     "spatialPredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
         "op": {
           "type": "string",
           "enum": [
-            "s_contains",
-            "s_crosses",
-            "s_disjoint",
-            "s_equals",
-            "s_intersects",
-            "s_overlaps",
-            "s_touches",
-            "s_within"
+            "s_contains"  , "s_crosses"   , "s_disjoint"  , "s_equals"    ,
+            "s_intersects", "s_overlaps"  , "s_touches"   , "s_within"
           ]
         },
-        "args": {
-          "$ref": "#/$defs/spatialOperands"
-        }
+        "args": {"$ref": "#/$defs/spatialOperands"}
       }
     },
     "spatialOperands": {
@@ -335,50 +205,28 @@
       "minItems": 2,
       "maxItems": 2,
       "items": {
-        "$ref": "#/$defs/geomExpression"
+        "oneOf": [
+          {"$ref": "#/$defs/spatialInstance"},
+          {"$ref": "#/$defs/propertyRef"    },
+          {"$ref": "#/$defs/functionRef"    }
+        ]
       }
     },
-    "geomExpression": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/spatialInstance"
-        },
-        {
-          "$ref": "#/$defs/propertyRef"
-        },
-        {
-          "$ref": "#/$defs/functionRef"
-        }
-      ]
-    },
-
     "temporalPredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
         "op": {
           "type": "string",
           "enum": [
-            "t_after",
-            "t_before",
-            "t_contains",
-            "t_disjoint",
-            "t_during",
-            "t_equals",
-            "t_finishedBy",
-            "t_finishes",
-            "t_intersects",
-            "t_meets",
-            "t_metBy",
-            "t_overlappedBy",
-            "t_overlaps",
-            "t_startedBy",
-            "t_starts"
+            "t_after"       , "t_before"      , "t_contains"    ,
+            "t_disjoint"    , "t_during"      , "t_equals"      ,
+            "t_finishedBy"  , "t_finishes"    , "t_intersects"  ,
+            "t_meets"       , "t_metBy"       , "t_overlappedBy",
+            "t_overlaps"    , "t_startedBy"   , "t_starts"
           ]
         },
-        "args": {
-          "$ref": "#/$defs/temporalOperands"
-        }
+        "args": {"$ref": "#/$defs/temporalOperands"}
       }
     },
     "temporalOperands": {
@@ -386,39 +234,22 @@
       "minItems": 2,
       "maxItems": 2,
       "items": {
-        "$ref": "#/$defs/temporalExpression"
+        "oneOf": [
+          {"$ref": "#/$defs/temporalInstance"},
+          {"$ref": "#/$defs/propertyRef"     },
+          {"$ref": "#/$defs/functionRef"     }
+        ]
       }
     },
-    "temporalExpression": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/temporalInstance"
-        },
-        {
-          "$ref": "#/$defs/propertyRef"
-        },
-        {
-          "$ref": "#/$defs/functionRef"
-        }
-      ]
-    },
-
     "arrayPredicate": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
         "op": {
           "type": "string",
-          "enum": [
-            "a_containedBy",
-            "a_contains",
-            "a_equals",
-            "a_overlaps"
-          ]
+          "enum": ["a_containedBy", "a_contains", "a_equals", "a_overlaps"]
         },
-        "args": {
-          "$ref": "#/$defs/arrayExpression"
-        }
+        "args": {"$ref": "#/$defs/arrayExpression"}
       }
     },
     "arrayExpression": {
@@ -427,15 +258,9 @@
       "maxItems": 2,
       "items": {
         "oneOf": [
-          {
-            "$ref": "#/$defs/array"
-          },
-          {
-            "$ref": "#/$defs/propertyRef"
-          },
-          {
-            "$ref": "#/$defs/functionRef"
-          }
+          {"$ref": "#/$defs/array"      },
+          {"$ref": "#/$defs/propertyRef"},
+          {"$ref": "#/$defs/functionRef"}
         ]
       }
     },
@@ -443,39 +268,25 @@
       "type": "array",
       "items": {
         "oneOf": [
-          {
-            "$ref": "#/$defs/characterExpression"
-          },
-          {
-            "$ref": "#/$defs/numericExpression"
-          },
-          {
-            "$dynamicRef": "#cql2expression"
-          },
-          {
-            "$ref": "#/$defs/geomExpression"
-          },
-          {
-            "$ref": "#/$defs/temporalExpression"
-          },
-          {
-            "$ref": "#/$defs/array"
-          }
+          {"$ref": "#/$defs/characterExpression"},
+          {"$ref": "#/$defs/numericExpression"}  ,
+          {"$dynamicRef": "#cql2expression"}     ,
+          {"$ref": "#/$defs/spatialInstance"}    ,
+          {"$ref": "#/$defs/temporalInstance"}   ,
+          {"$ref": "#/$defs/array"}              ,
+          {"$ref": "#/$defs/propertyRef"}
         ]
       }
     },
-
     "arithmeticExpression": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
         "op": {
           "type": "string",
-          "enum": [ "+", "-", "*", "/", "^", "%", "div" ]
+          "enum": ["+", "-", "*", "/", "^", "%", "div"]
         },
-        "args": {
-          "$ref": "#/$defs/arithmeticOperands"
-        }
+        "args": {"$ref": "#/$defs/arithmeticOperands"}
       }
     },
     "arithmeticOperands": {
@@ -484,227 +295,170 @@
       "maxItems": 2,
       "items": {
         "oneOf": [
-          {
-            "$ref": "#/$defs/arithmeticExpression"
-          },
-          {
-            "$ref": "#/$defs/propertyRef"
-          },
-          {
-            "$ref": "#/$defs/functionRef"
-          },
-          {
-            "type": "number"
-          }
+          {"$ref": "#/$defs/arithmeticExpression"                  },
+          {"$ref": "#/$defs/propertyRef"                           },
+          {"$ref": "#/$defs/functionRef"                           },
+          {                                        "type": "number"}
         ]
       }
     },
-
     "propertyRef": {
       "type": "object",
-      "required": [ "property" ],
-      "properties": {
-        "property": {
-          "type": "string"
-        }
-      }
+      "required": ["property"],
+      "properties": { "property": {"type": "string"} }
     },
-
     "casei": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": { "type": "string", "enum": [ "casei" ] },
+        "op": { "type": "string", "enum": ["casei"] },
         "args": {
           "type": "array",
-          "items": { "$ref": "#/$defs/characterExpression" },
+          "items": {
+            "oneOf": [
+              {"$ref": "#/$defs/characterExpression"},
+              {"$ref": "#/$defs/propertyRef"        },
+              {"$ref": "#/$defs/functionRef"        }
+            ]
+          },
           "minItems": 1,
           "maxItems": 1
         }
       }
     },
-
     "accenti": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
-        "op": { "type": "string", "enum": [ "accenti" ] },
+        "op": { "type": "string", "enum": ["accenti"] },
         "args": {
           "type": "array",
-          "items": { "$ref": "#/$defs/characterExpression" },
+          "items": {
+            "oneOf": [
+              {"$ref": "#/$defs/characterExpression"},
+              {"$ref": "#/$defs/propertyRef"        },
+              {"$ref": "#/$defs/functionRef"        }
+            ]
+          },
           "minItems": 1,
           "maxItems": 1
         }
       }
     },
-
     "characterExpression": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/casei"
-        },
-        {
-          "$ref": "#/$defs/accenti"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/propertyRef"
-        },
-        {
-          "$ref": "#/$defs/functionRef"
-        }
+        {"$ref": "#/$defs/casei"                    },
+        {"$ref": "#/$defs/accenti"                  },
+        {                           "type": "string"}
       ]
     },
-
     "functionRef": {
       "type": "object",
-      "required": [ "op", "args" ],
+      "required": ["op", "args"],
       "properties": {
         "op": {
-          "type": "string"
+          "type": "string",
+          "not": {
+            "enum": [
+              "and"           , "or"            , "not"           ,
+              "="             , "<>"            , "<"             ,
+              ">"             , "<="            , ">="            ,
+              "like"          , "between"       , "in"            ,
+              "isNull"        , "casei"         , "accenti"       ,
+              "s_contains"    , "s_crosses"     , "s_disjoint"    ,
+              "s_equals"      , "s_intersects"  , "s_overlaps"    ,
+              "s_touches"     , "s_within"      , "t_after"       ,
+              "t_before"      , "t_contains"    , "t_disjoint"    ,
+              "t_during"      , "t_equals"      , "t_finishedBy"  ,
+              "t_finishes"    , "t_intersects"  , "t_meets"       ,
+              "t_metBy"       , "t_overlappedBy", "t_overlaps"    ,
+              "t_startedBy"   , "t_starts"      , "a_containedBy" ,
+              "a_contains"    , "a_equals"      , "a_overlaps"    ,
+              "+"             , "-"             , "*"             ,
+              "/"             , "^"             , "%"             ,
+              "div"
+            ]
+          }
         },
         "args": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "$ref": "#/$defs/characterExpression"
-              },
-              {
-                "$ref": "#/$defs/numericExpression"
-              },
-              {
-                "$dynamicRef": "#cql2expression"
-              },
-              {
-                "$ref": "#/$defs/geomExpression"
-              },
-              {
-                "$ref": "#/$defs/temporalExpression"
-              },
-              {
-                "$ref": "#/$defs/array"
-              }
+              {"$ref": "#/$defs/characterExpression"},
+              {"$ref": "#/$defs/numericExpression"}  ,
+              {"$dynamicRef": "#cql2expression"}     ,
+              {"$ref": "#/$defs/spatialInstance"}    ,
+              {"$ref": "#/$defs/temporalInstance"}   ,
+              {"$ref": "#/$defs/array"}              ,
+              {"$ref": "#/$defs/propertyRef"}
             ]
           }
         }
       }
     },
-
     "scalarLiteral": {
       "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/$defs/instantInstance"
-        }
+        {"type": "string"                                    },
+        {"type": "number"                                    },
+        {"type": "boolean"                                   },
+        {                   "$ref": "#/$defs/instantInstance"}
       ]
     },
-
     "spatialInstance": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/geometryLiteral"
-        },
-        {
-          "$ref": "#/$defs/bboxLiteral"
-        }
+        {"$ref": "#/$defs/geometryLiteral"},
+        {"$ref": "#/$defs/bboxLiteral"    }
       ]
     },
     "geometryLiteral": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/point"
-        },
-        {
-          "$ref": "#/$defs/linestring"
-        },
-        {
-          "$ref": "#/$defs/polygon"
-        },
-        {
-          "$ref": "#/$defs/multipoint"
-        },
-        {
-          "$ref": "#/$defs/multilinestring"
-        },
-        {
-          "$ref": "#/$defs/multipolygon"
-        }
+        {"$ref": "#/$defs/point"             },
+        {"$ref": "#/$defs/linestring"        },
+        {"$ref": "#/$defs/polygon"           },
+        {"$ref": "#/$defs/multipoint"        },
+        {"$ref": "#/$defs/multilinestring"   },
+        {"$ref": "#/$defs/multipolygon"      },
+        {"$ref": "#/$defs/geometrycollection"}
       ]
     },
     "point": {
       "title": "GeoJSON Point",
       "type": "object",
-      "required": [ "type", "coordinates" ],
+      "required": ["type", "coordinates"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [ "Point" ]
-        },
+        "type": { "type": "string", "enum": ["Point"] },
         "coordinates": {
           "type": "array",
           "minItems": 2,
-          "items": {
-            "type": "number"
-          }
+          "items": {"type": "number"}
         },
-        "bbox": {
-          "type": "array",
-          "minItems": 4,
-          "items": {
-            "type": "number"
-          }
-        }
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
       }
     },
     "linestring": {
       "title": "GeoJSON LineString",
       "type": "object",
-      "required": [ "type", "coordinates" ],
+      "required": ["type", "coordinates"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [ "LineString" ]
-        },
+        "type": { "type": "string", "enum": ["LineString"] },
         "coordinates": {
           "type": "array",
           "minItems": 2,
           "items": {
             "type": "array",
             "minItems": 2,
-            "items": {
-              "type": "number"
-            }
+            "items": {"type": "number"}
           }
         },
-        "bbox": {
-          "type": "array",
-          "minItems": 4,
-          "items": {
-            "type": "number"
-          }
-        }
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
       }
     },
     "polygon": {
       "title": "GeoJSON Polygon",
       "type": "object",
-      "required": [ "type", "coordinates" ],
+      "required": ["type", "coordinates"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [ "Polygon" ]
-        },
+        "type": { "type": "string", "enum": ["Polygon"] },
         "coordinates": {
           "type": "array",
           "items": {
@@ -713,58 +467,36 @@
             "items": {
               "type": "array",
               "minItems": 2,
-              "items": {
-                "type": "number"
-              }
+              "items": {"type": "number"}
             }
           }
         },
-        "bbox": {
-          "type": "array",
-          "minItems": 4,
-          "items": {
-            "type": "number"
-          }
-        }
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
       }
     },
     "multipoint": {
       "title": "GeoJSON MultiPoint",
       "type": "object",
-      "required": [ "type", "coordinates" ],
+      "required": ["type", "coordinates"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [ "MultiPoint" ]
-        },
+        "type": { "type": "string", "enum": ["MultiPoint"] },
         "coordinates": {
           "type": "array",
           "items": {
             "type": "array",
             "minItems": 2,
-            "items": {
-              "type": "number"
-            }
+            "items": {"type": "number"}
           }
         },
-        "bbox": {
-          "type": "array",
-          "minItems": 4,
-          "items": {
-            "type": "number"
-          }
-        }
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
       }
     },
     "multilinestring": {
       "title": "GeoJSON MultiLineString",
       "type": "object",
-      "required": [ "type", "coordinates" ],
+      "required": ["type", "coordinates"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [ "MultiLineString" ]
-        },
+        "type": { "type": "string", "enum": ["MultiLineString"] },
         "coordinates": {
           "type": "array",
           "items": {
@@ -773,30 +505,19 @@
             "items": {
               "type": "array",
               "minItems": 2,
-              "items": {
-                "type": "number"
-              }
+              "items": {"type": "number"}
             }
           }
         },
-        "bbox": {
-          "type": "array",
-          "minItems": 4,
-          "items": {
-            "type": "number"
-          }
-        }
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
       }
     },
     "multipolygon": {
       "title": "GeoJSON MultiPolygon",
       "type": "object",
-      "required": [ "type", "coordinates" ],
+      "required": ["type", "coordinates"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [ "MultiPolygon" ]
-        },
+        "type": { "type": "string", "enum": ["MultiPolygon"] },
         "coordinates": {
           "type": "array",
           "items": {
@@ -807,116 +528,86 @@
               "items": {
                 "type": "array",
                 "minItems": 2,
-                "items": {
-                  "type": "number"
-                }
+                "items": {"type": "number"}
               }
             }
           }
         },
-        "bbox": {
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
+      }
+    },
+    "geometrycollection": {
+      "title": "GeoJSON GeometryCollection",
+      "type": "object",
+      "required": ["type", "geometries"],
+      "properties": {
+        "type": { "type": "string", "enum": ["GeometryCollection"] },
+        "geometries": {
           "type": "array",
-          "minItems": 4,
+          "minItems": 2,
           "items": {
-            "type": "number"
+            "oneOf": [
+              {"$ref": "#/$defs/point"          },
+              {"$ref": "#/$defs/linestring"     },
+              {"$ref": "#/$defs/polygon"        },
+              {"$ref": "#/$defs/multipoint"     },
+              {"$ref": "#/$defs/multilinestring"},
+              {"$ref": "#/$defs/multipolygon"   }
+            ]
           }
         }
       }
     },
     "bboxLiteral": {
       "type": "object",
-      "required": [
-        "bbox"
-      ],
-      "properties": {
-        "bbox": {
-          "$ref": "#/$defs/bbox"
-        }
-      }
+      "required": ["bbox"],
+      "properties": { "bbox": {"$ref": "#/$defs/bbox"} }
     },
     "bbox": {
       "type": "array",
       "oneOf": [
-        {
-          "minItems": 4,
-          "maxItems": 4
-        },
-        {
-          "minItems": 6,
-          "maxItems": 6
-        }
+        {"minItems": 4, "maxItems": 4},
+        {"minItems": 6, "maxItems": 6}
       ],
-      "items": {
-        "type": "number"
-      }
+      "items": {"type": "number"}
     },
-
     "temporalInstance": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/instantInstance"
-        },
-        {
-          "$ref": "#/$defs/intervalInstance"
-        }
+        {"$ref": "#/$defs/instantInstance" },
+        {"$ref": "#/$defs/intervalInstance"}
       ]
     },
     "instantInstance": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/dateInstant"
-        },
-        {
-          "$ref": "#/$defs/timestampInstant"
-        }
+        {"$ref": "#/$defs/dateInstant"     },
+        {"$ref": "#/$defs/timestampInstant"}
       ]
     },
     "dateInstant": {
       "type": "object",
-      "required": [ "date" ],
-      "properties": {
-        "date": {
-          "$ref": "#/$defs/dateString"
-        }
-      }
+      "required": ["date"],
+      "properties": { "date": {"$ref": "#/$defs/dateString"} }
     },
     "timestampInstant": {
       "type": "object",
-      "required": [ "timestamp" ],
-      "properties": {
-        "timestamp": {
-          "$ref": "#/$defs/timestampString"
-        }
-      }
+      "required": ["timestamp"],
+      "properties": { "timestamp": {"$ref": "#/$defs/timestampString"} }
     },
     "instantString": {
       "oneOf": [
-        {
-          "$ref": "#/$defs/dateString"
-        },
-        {
-          "$ref": "#/$defs/timestampString"
-        }
+        {"$ref": "#/$defs/dateString"     },
+        {"$ref": "#/$defs/timestampString"}
       ]
     },
-    "dateString": {
-      "type": "string",
-      "format": "date"
-    },
+    "dateString": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
     "timestampString": {
-      "type": "string",
-      "format": "date-time"
+      "type"   : "string"                                                  ,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "intervalInstance": {
       "type": "object",
-      "required": [
-        "interval"
-      ],
-      "properties": {
-        "interval": {
-          "$ref": "#/$defs/intervalArray"
-        }
-      }
+      "required": ["interval"],
+      "properties": { "interval": {"$ref": "#/$defs/intervalArray"} }
     },
     "intervalArray": {
       "type": "array",
@@ -924,21 +615,10 @@
       "maxItems": 2,
       "items": {
         "oneOf": [
-          {
-            "$ref": "#/$defs/instantString"
-          },
-          {
-            "type": "string",
-            "enum": [
-              ".."
-            ]
-          },
-          {
-            "$ref": "#/$defs/propertyRef"
-          },
-          {
-            "$ref": "#/$defs/functionRef"
-          }
+          {"$ref": "#/$defs/instantString"}   ,
+          { "type": "string", "enum": [".."] },
+          {"$ref": "#/$defs/propertyRef"}     ,
+          {"$ref": "#/$defs/functionRef"}
         ]
       }
     }

--- a/cql2/standard/schema/examples/json/clause6_01.json
+++ b/cql2/standard/schema/examples/json/clause6_01.json
@@ -1,1 +1,1 @@
-{ "function": { "name": "avg", "args": [ { "property": "windSpeed" } ] } }
+{ "op": "avg", "args": [ { "property": "windSpeed" } ] }

--- a/cql2/standard/schema/examples/json/clause6_02b.json
+++ b/cql2/standard/schema/examples/json/clause6_02b.json
@@ -2,10 +2,8 @@
   "op": "<",
   "args": [
     {
-      "function": {
-        "name": "avg",
-        "args": [ { "property": "windSpeed" } ]
-      }
+      "op": "avg",
+      "args": [ { "property": "windSpeed" } ]
     },
     4
   ]

--- a/cql2/standard/schema/examples/json/clause7_18.json
+++ b/cql2/standard/schema/examples/json/clause7_18.json
@@ -3,14 +3,12 @@
   "args": [
     { "property": "road" },
     {
-      "function": {
-        "name": "Buffer",
-        "args": [
-          { "property": "geometry" },
-          10,
-          "m"
-        ]
-      }
+      "op": "Buffer",
+      "args": [
+        { "property": "geometry" },
+        10,
+        "m"
+      ]
     }
   ]
 }

--- a/cql2/standard/schema/examples/json/example68.json
+++ b/cql2/standard/schema/examples/json/example68.json
@@ -2,10 +2,8 @@
   "op": "=",
   "args": [
     {
-      "function": {
-        "name": "Foo",
-        "args": [ { "property": "geometry" } ]
-      }
+      "op": "Foo",
+      "args": [ { "property": "geometry" } ]
     },
     true
   ]

--- a/cql2/standard/schema/examples/json/example69.json
+++ b/cql2/standard/schema/examples/json/example69.json
@@ -3,10 +3,8 @@
   "args": [
     false,
     {
-      "function": {
-        "name": "Bar",
-        "args": [ { "property": "geometry" }, 100, "a", "b", false ]
-      }
+      "op": "Bar",
+      "args": [ { "property": "geometry" }, 100, "a", "b", false ]
     }
   ]
 }

--- a/cql2/standard/schema/examples/json/validate.sh
+++ b/cql2/standard/schema/examples/json/validate.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# validation using https://www.npmjs.com/package/ajv-cli
+
+# validate all examples
+for f in *.json
+do
+    ajv validate -s "../../cql2.json" --spec=draft2020 --validateFormats=false --strict=true --errors=no -d $f
+done


### PR DESCRIPTION
- [x] Add script to validate all examples.
- [x] Fix CQL2 JSON schema. Closes #901.
  - Include "propertyRef" and "functionRef" definitions only once in "oneOf".
  - In "functionRef", exclude all built-in CQL2 functions.
  - GeometryCollection was not supported as a geometry.
  - Change date/timestamp formats to a pattern to avoid practical validation issues.
- [x] Upgrade schema to JSON Schema 2020-12.
- [x] Fix invalid examples.
- [ ] Update OpenAPI 3.0 schema for CQL2 to the latest changes.

@pvretano @clausnagel - This should fix the validation issues. Could you have a look at the changes?