### PR TITLE
CQL2 Text: update spatialLiteral rule

### DIFF
--- a/asciidoctor.json
+++ b/asciidoctor.json
@@ -74,7 +74,7 @@
                 ]
         },
         "5":  {
-                "OGC_doc_number": "21-065",
+                "OGC_doc_number": "21-065r1",
                 "urn":"http://www.opengis.net/doc/IS/cql2/1.0",
                 "title":"Common Query Language (CQL2)",
                 "path":"cql2/standard/21-065.adoc",

--- a/cql2/standard/21-065.adoc
+++ b/cql2/standard/21-065.adoc
@@ -33,8 +33,8 @@
 |Approval Date:  <yyyy-mm-dd>
 |Publication Date:  <yyyy-mm-dd>
 |External identifier of this OGC(R) document: http://www.opengis.net/doc/IS/{standard}/{m_n}
-|Internal reference number of this OGC(R) document:    21-065
-|Version: {m_n}.0-rc.1
+|Internal reference number of this OGC(R) document:    21-065r1
+|Version: {m_n}.0-rc.2
 |Latest Published Draft: n/a
 |Category: OGC(R) Implementation Specification
 |Editors: Panagiotis (Peter) A. Vretanos, Clemens Portele

--- a/cql2/standard/annex_ats_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/annex_ats_basic-spatial-functions-plus.adoc
@@ -20,7 +20,7 @@ The term "geometry data type" is used for the following data types: Point, Multi
 |===
 |Test id: | /conf/{conf-class}/{conf-test}
 |Requirements: | <<req_{conf-class}_spatial-predicate,/req/{conf-class}/spatial-predicate>>, <<req_{conf-class}_spatial-functions,/req/{conf-class}/spatial-functions>>, <<req_{conf-class}_spatial-functions,/req/{conf-class}/spatial-data-types>>
-|Test purpose: | Test the S_INTERSECTS spatial comparison function with points, multi-points, line strings, multi-line string, polyons, mult-polygons, geometry collections and bounding boxes.
+|Test purpose: | Test the S_INTERSECTS spatial comparison function with points, multi-points, line strings, multi-line string, polyons, multi-polygons, geometry collections and bounding boxes.
 |Test method: | 
 Given:
 

--- a/cql2/standard/annex_ats_cql2-json.adoc
+++ b/cql2/standard/annex_ats_cql2-json.adoc
@@ -13,6 +13,7 @@
 |Conditional Dependency |<<conf_case-insensitive-comparison,Case-insensitive Comparisons>>
 |Conditional Dependency |<<conf_accent-insensitive-comparison,Accent-insensitive Comparisons>>
 |Conditional Dependency |<<conf_basic-spatial-functions,Basic Spatial Functions>>
+|Conditional Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
 |Conditional Dependency |<<conf_spatial-functions,Spatial Functions>>
 |Conditional Dependency |<<conf_temporal-functions,Temporal Functions>>
 |Conditional Dependency |<<conf_array-functions,Array Functions>>

--- a/cql2/standard/annex_ats_cql2-text.adoc
+++ b/cql2/standard/annex_ats_cql2-text.adoc
@@ -13,6 +13,7 @@
 |Conditional Dependency |<<conf_case-insensitive-comparison,Case-insensitive Comparisons>>
 |Conditional Dependency |<<conf_accent-insensitive-comparison,Accent-insensitive Comparisons>>
 |Conditional Dependency |<<conf_basic-spatial-functions,Basic Spatial Functions>>
+|Conditional Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
 |Conditional Dependency |<<conf_spatial-functions,Spatial Functions>>
 |Conditional Dependency |<<conf_temporal-functions,Temporal Functions>>
 |Conditional Dependency |<<conf_array-functions,Array Functions>>

--- a/cql2/standard/clause_7_enhanced.adoc
+++ b/cql2/standard/clause_7_enhanced.adoc
@@ -306,7 +306,7 @@ In addition to the spatial types listed in the <<basic-spatial-functions,Basic S
 * "MultiPoint": a collection of points;
 * "MultiLineString": a collection of line strings;
 * "MultiPolygon": a collection of polygons;
-* "GeometryCollection": a collection of one or more of "Point", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon" or "GeometryCollection"  instances;
+* "GeometryCollection": a collection of one or more of "Point", "Polygon", "MultiPoint", "MultiLineString", or "MultiPolygon" instances;
 
 include::requirements/basic-spatial-functions-plus/REQ_spatial-data-types.adoc[]
 

--- a/cql2/standard/clause_8_encodings.adoc
+++ b/cql2/standard/clause_8_encodings.adoc
@@ -88,6 +88,12 @@ include::requirements/cql2-text/REQ_accent-insensitive-comparison.adoc[]
 
 include::requirements/cql2-text/REQ_basic-spatial-functions.adoc[]
 
+include::requirements/cql2-text/REQ_basic-spatial-functions-plus.adoc[]
+
+OGC WKT uses a "Z" character to distinguish the dimensionality of the coordinate reference system (CRS), e.g. `POINT(7 51)` for a 2D CRS and `POINT Z(7 51 100)` for a 3D CRS. In CQL2 Text, processors are required to be more tolerant and to determine the coordinate dimension from the coordinates.
+
+When creating a CQL2 Text expression, it is recommended to encode a geometry literal as required by OGC WKT.
+
 include::requirements/cql2-text/REQ_spatial-functions.adoc[]
 
 include::requirements/cql2-text/REQ_temporal-functions.adoc[]
@@ -119,6 +125,8 @@ include::requirements/cql2-json/REQ_case-insensitive-comparison.adoc[]
 include::requirements/cql2-json/REQ_accent-insensitive-comparison.adoc[]
 
 include::requirements/cql2-json/REQ_basic-spatial-functions.adoc[]
+
+include::requirements/cql2-json/REQ_basic-spatial-functions-plus.adoc[]
 
 include::requirements/cql2-json/REQ_spatial-functions.adoc[]
 

--- a/cql2/standard/requirements/basic-spatial-functions-plus/REQ_spatial-data-types.adoc
+++ b/cql2/standard/requirements/basic-spatial-functions-plus/REQ_spatial-data-types.adoc
@@ -1,6 +1,6 @@
-[[req_spatial-functions_spatial-data-types]]
+[[req_basic-spatial-functions-plus_spatial-data-types]]
 [width="90%",cols="2,6a"]
 |===
-^|*Requirement {counter:req-id}* |*/req/spatial-functions/spatial-data-types*
+^|*Requirement {counter:req-id}* |*/req/basic-spatial-functions-plus/spatial-data-types*
 ^|A |The server SHALL support all spatial literals as defined by the BNF rule `spatialInstance` in <<cql2-bnf>>.
 |===

--- a/cql2/standard/requirements/cql2-json/REQ_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/requirements/cql2-json/REQ_basic-spatial-functions-plus.adoc
@@ -1,0 +1,9 @@
+[[req_cql2-json_basic-spatial-functions-plus]] 
+[width="90%",cols="2,6a"]
+|===
+^|*Requirement {counter:req-id}* |*/req/cql2-json/basic-spatial-functions-plus* 
+^|Condition |Server implements requirements class <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
+^|A |The server SHALL be able to parse and evaluate filter expressions encoded as JSON that use the following schema components:
+
+* "#/$defs/spatialPredicate" where property "op" has the value "s_intersects"
+|===

--- a/cql2/standard/requirements/cql2-text/REQ_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_basic-spatial-functions-plus.adoc
@@ -1,0 +1,8 @@
+[[req_cql2-text_basic-spatial-functions-plus]]
+[width="90%",cols="2,6a"]
+|===
+^|*Requirement {counter:req-id}* |*/req/cql2-text/basic-spatial-functions-plus*
+^|Condition |Server implements requirements class <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
+^|A |The server SHALL support be able to parse all spatial instances encoded as a text string that validate against the BNF production fragments identified in the <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>> requirements class.
+^|B |The server SHALL support spatial literals with coordinates in a 2D or 3D CRS, independent of including the `Z` or not in the value.
+|===

--- a/cql2/standard/requirements/requirements_class_cql2-json.adoc
+++ b/cql2/standard/requirements/requirements_class_cql2-json.adoc
@@ -10,6 +10,7 @@
 |Conditional Dependency |<<rc_case-insensitive-comparison,Requirements Class "Case-insensitive Comparisons">>
 |Conditional Dependency |<<rc_accent-insensitive-comparison,Requirements Class "Accent-insensitive Comparisons">>
 |Conditional Dependency |<<rc_basic-spatial-functions,Requirements Class "Basic Spatial Functions">>
+|Conditional Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Data Types">>
 |Conditional Dependency |<<rc_spatial-functions,Requirements Class "Spatial Functions">>
 |Conditional Dependency |<<rc_temporal-functions,Requirements Class "Temporal Functions">>
 |Conditional Dependency |<<rc_array-functions,Requirements Class "Array Functions">>

--- a/cql2/standard/requirements/requirements_class_cql2-text.adoc
+++ b/cql2/standard/requirements/requirements_class_cql2-text.adoc
@@ -10,6 +10,7 @@
 |Conditional Dependency |<<rc_case-insensitive-comparison,Requirements Class "Case-insensitive Comparisons">>
 |Conditional Dependency |<<rc_accent-insensitive-comparison,Requirements Class "Accent-insensitive Comparisons">>
 |Conditional Dependency |<<rc_basic-spatial-functions,Requirements Class "Basic Spatial Functions">>
+|Conditional Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Data Types">>
 |Conditional Dependency |<<rc_spatial-functions,Requirements Class "Spatial Functions">>
 |Conditional Dependency |<<rc_temporal-functions,Requirements Class "Temporal Functions">>
 |Conditional Dependency |<<rc_array-functions,Requirements Class "Array Functions">>

--- a/cql2/standard/schema/cql2.bnf
+++ b/cql2/standard/schema/cql2.bnf
@@ -513,28 +513,30 @@ booleanLiteral = "TRUE" | "FALSE";
 # NOTE: This is basically BNF that define WKT encoding. It would be nice
 #       to instead reference some normative BNF for WKT.
 #=============================================================================#
-spatialInstance = pointTaggedText
+spatialInstance = geometryLiteral       
+                | geometryCollectionTaggedText
+                | bboxTaggedText;
+
+geometryLiteral = pointTaggedText
                 | linestringTaggedText
                 | polygonTaggedText
                 | multipointTaggedText
                 | multilinestringTaggedText
-                | multipolygonTaggedText
-                | geometryCollectionTaggedText
-                | bboxTaggedText;
+                | multipolygonTaggedText;
 
-pointTaggedText = "POINT" pointText;
+pointTaggedText = "POINT" ["Z"] pointText;
 
-linestringTaggedText = "LINESTRING" lineStringText;
+linestringTaggedText = "LINESTRING" ["Z"] lineStringText;
 
-polygonTaggedText = "POLYGON" polygonText;
+polygonTaggedText = "POLYGON" ["Z"] polygonText;
 
-multipointTaggedText = "MULTIPOINT" multiPointText;
+multipointTaggedText = "MULTIPOINT" ["Z"] multiPointText;
 
-multilinestringTaggedText = "MULTILINESTRING" multiLineStringText;
+multilinestringTaggedText = "MULTILINESTRING" ["Z"] multiLineStringText;
 
-multipolygonTaggedText = "MULTIPOLYGON" multiPolygonText;
+multipolygonTaggedText = "MULTIPOLYGON" ["Z"] multiPolygonText;
 
-geometryCollectionTaggedText = "GEOMETRYCOLLECTION" geometryCollectionText;
+geometryCollectionTaggedText = "GEOMETRYCOLLECTION" ["Z"] geometryCollectionText;
 
 pointText = "(" point ")";
 
@@ -546,9 +548,11 @@ yCoord = signedNumericLiteral;
 
 zCoord = signedNumericLiteral;
 
-lineStringText = "(" point {"," point} ")";
+lineStringText = "(" point "," point {"," point} ")";
 
-polygonText =  "(" lineStringText {"," lineStringText} ")";
+linearRingText = emptySet | "(" point "," point "," point "," point {"," point } ")";
+
+polygonText =  "(" linearRingText {"," linearRingText} ")";
 
 multiPointText = "(" pointText {"," pointText} ")";
 
@@ -556,7 +560,7 @@ multiLineStringText = "(" lineStringText {"," lineStringText} ")";
 
 multiPolygonText = "(" polygonText {"," polygonText} ")";
 
-geometryCollectionText = "(" spatialInstance {"," spatialInstance} ")";
+geometryCollectionText = "(" geometryLiteral {"," geometryLiteral} ")";
 
 bboxTaggedText = "BBOX" bboxText;
 


### PR DESCRIPTION
Closes #800. 

As discussed in https://github.com/opengeospatial/ogcapi-features/issues/800#issuecomment-1987256292, all suggestions are included except the proposal to support EMPTY in WKT geometries.

In addition, the following changes are included:

- change version and document generation to 21-065r1
- add missing requirements for the `basic-spatial-functions-plus` requirements class in the encoding requirements classes
- add missing conditional dependencies in the encoding ATSs
- fix a spelling mistake in the ATS
- fix an incorrect requirement identifier