### PR TITLE
"((" needs to be escaped in AsciiDoc, except in code blocks

### DIFF
--- a/cql2/standard/annex_ats_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/annex_ats_basic-spatial-functions-plus.adoc
@@ -33,10 +33,10 @@ For each queryable `{queryable}` with a geometry data type, evaluate the followi
 
 * `S_INTERSECTS({queryable},MULTIPOINT(7.02 49.92, 90 180))`
 * `S_INTERSECTS({queryable},LINESTRING(-180 -45, 0 -45))`
-* `S_INTERSECTS({queryable},MULTILINESTRING((-180 -45, 0 -45), (0 45, 180 45)))`
-* `S_INTERSECTS({queryable},POLYGON((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)))`
-* `S_INTERSECTS({queryable},MULTIPOLYGON(((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)),((0 0, 10 0, 10 10, 0 10, 0 0))))`
-* `S_INTERSECTS({queryable},GEOMETRYCOLLECTION(POINT(7.02 49.92), POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))))`
+* `S_INTERSECTS({queryable},MULTILINESTRING\((-180 -45, 0 -45), (0 45, 180 45)))`
+* `S_INTERSECTS({queryable},POLYGON\((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)))`
+* `S_INTERSECTS({queryable},MULTIPOLYGON(\((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)),\((0 0, 10 0, 10 10, 0 10, 0 0))))`
+* `S_INTERSECTS({queryable},GEOMETRYCOLLECTION(POINT(7.02 49.92), POLYGON\((0 0, 10 0, 10 10, 0 10, 0 0))))`
 
 Then:
 
@@ -73,10 +73,10 @@ Then:
 |===
 |Data Source |Predicate |Expected number of items
 |ne_110m_admin_0_countries |`S_INTERSECTS(geom,LINESTRING(-180 -45, 0 -45))` |2
-|ne_110m_admin_0_countries |`S_INTERSECTS(geom,MULTILINESTRING((-180 -45, 0 -45), (0 45, 180 45)))` |14
-|ne_110m_admin_0_countries |`S_INTERSECTS(geom,POLYGON((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)))` |8
-|ne_110m_admin_0_countries |`S_INTERSECTS(geom,MULTIPOLYGON(((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)),((0 0, 10 0, 10 10, 0 10, 0 0))))` |15
-|ne_110m_admin_0_countries |`S_INTERSECTS(geom,GEOMETRYCOLLECTION(POINT(7.02 49.92), POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))))` |8
-|ne_110m_admin_0_countries |`S_INTERSECTS(geom,POLYGON((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50))) or S_INTERSECTS(geom,POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)))` |15
-|ne_110m_admin_0_countries |`S_INTERSECTS(geom,POLYGON((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50))) and not S_INTERSECTS(geom,POLYGON((-130 0, 0 0, 0 50, -130 50, -130 0)))` |3
+|ne_110m_admin_0_countries |`S_INTERSECTS(geom,MULTILINESTRING\((-180 -45, 0 -45), (0 45, 180 45)))` |14
+|ne_110m_admin_0_countries |`S_INTERSECTS(geom,POLYGON\((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)))` |8
+|ne_110m_admin_0_countries |`S_INTERSECTS(geom,MULTIPOLYGON(\((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50)),\((0 0, 10 0, 10 10, 0 10, 0 0))))` |15
+|ne_110m_admin_0_countries |`S_INTERSECTS(geom,GEOMETRYCOLLECTION(POINT(7.02 49.92), POLYGON\((0 0, 10 0, 10 10, 0 10, 0 0))))` |8
+|ne_110m_admin_0_countries |`S_INTERSECTS(geom,POLYGON\((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50))) or S_INTERSECTS(geom,POLYGON\((0 0, 10 0, 10 10, 0 10, 0 0)))` |15
+|ne_110m_admin_0_countries |`S_INTERSECTS(geom,POLYGON\((-180 -90, -90 -90, -90 90, -180 90, -180 -90), (-120 -50, -100 -50, -100 -40, -120 -40, -120 -50))) and not S_INTERSECTS(geom,POLYGON\((-130 0, 0 0, 0 50, -130 50, -130 0)))` |3
 |===


### PR DESCRIPTION
Not all cases where "((" was used in CQL2 expressions were properly escaped.