### PR TITLE
Clarify wording on spatial literals

### DIFF
--- a/cql2/standard/annex_ats_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/annex_ats_basic-spatial-functions-plus.adoc
@@ -1,4 +1,4 @@
-=== Conformance Class "Basic Spatial Functions with additional Spatial Data Types"
+=== Conformance Class "Basic Spatial Functions with additional Spatial Literals"
 
 :conf-class: basic-spatial-functions-plus
 [[conf_basic-spatial-functions-plus]]
@@ -8,7 +8,7 @@
 2+|http://www.opengis.net/spec/{standard}/{m_n}/conf/{conf-class}
 |Target type |Servers that evaluate filter expressions
 |Parameter |Filter Language: "CQL2 Text" or "CQL2 JSON"
-|Requirements class |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Data Types">>
+|Requirements class |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Literals">>
 |Dependency |<<conf_basic-spatial-functions,Basic Spatial Functions>>
 |===
 

--- a/cql2/standard/annex_ats_cql2-json.adoc
+++ b/cql2/standard/annex_ats_cql2-json.adoc
@@ -13,7 +13,7 @@
 |Conditional Dependency |<<conf_case-insensitive-comparison,Case-insensitive Comparisons>>
 |Conditional Dependency |<<conf_accent-insensitive-comparison,Accent-insensitive Comparisons>>
 |Conditional Dependency |<<conf_basic-spatial-functions,Basic Spatial Functions>>
-|Conditional Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
+|Conditional Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>>
 |Conditional Dependency |<<conf_spatial-functions,Spatial Functions>>
 |Conditional Dependency |<<conf_temporal-functions,Temporal Functions>>
 |Conditional Dependency |<<conf_array-functions,Array Functions>>

--- a/cql2/standard/annex_ats_cql2-text.adoc
+++ b/cql2/standard/annex_ats_cql2-text.adoc
@@ -13,7 +13,7 @@
 |Conditional Dependency |<<conf_case-insensitive-comparison,Case-insensitive Comparisons>>
 |Conditional Dependency |<<conf_accent-insensitive-comparison,Accent-insensitive Comparisons>>
 |Conditional Dependency |<<conf_basic-spatial-functions,Basic Spatial Functions>>
-|Conditional Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
+|Conditional Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>>
 |Conditional Dependency |<<conf_spatial-functions,Spatial Functions>>
 |Conditional Dependency |<<conf_temporal-functions,Temporal Functions>>
 |Conditional Dependency |<<conf_array-functions,Array Functions>>

--- a/cql2/standard/annex_ats_spatial-functions.adoc
+++ b/cql2/standard/annex_ats_spatial-functions.adoc
@@ -9,7 +9,7 @@
 |Target type |Servers that evaluate filter expressions
 |Parameter |Filter Language: "CQL2 Text" or "CQL2 JSON"
 |Requirements class |<<rc_spatial-functions,Requirements Class "Spatial Functions">>
-|Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
+|Dependency |<<conf_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>>
 |===
 
 :conf-test: s_intersects

--- a/cql2/standard/clause_2_conformance.adoc
+++ b/cql2/standard/clause_2_conformance.adoc
@@ -9,7 +9,7 @@ grouped by their standardization target:
 ** <<rc_case-insensitive-comparison,Case-insensitive Comparisons>>
 ** <<rc_accent-insensitive-comparison,Accent-insensitive Comparisons>>
 ** <<rc_basic-spatial-functions,Basic Spatial Functions>>
-** <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
+** <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>>
 ** <<rc_spatial-functions,Spatial Functions>>
 ** <<rc_temporal-functions,Temporal Functions>>
 ** <<rc_array-functions,Array Functions>>
@@ -65,7 +65,7 @@ The <<rc_basic-spatial-functions,Basic Spatial Functions>> requirements class sp
 
 * s_intersects
 
-The <<rc_basic-spatial-functions,Basic Spatial Functions with additional Spatial Data Types>> requirements class is similar to the <<rc_basic-spatial-functions,Basic Spatial Functions>> requirements class except it removes the restrictions on the spatial data types that may participate in the expression.
+The <<rc_basic-spatial-functions,Basic Spatial Functions with additional Spatial Literals>> requirements class is similar to the <<rc_basic-spatial-functions,Basic Spatial Functions>> requirements class except it removes the restrictions on the spatial literals that may be used in the expression.
 
 The <<rc_spatial-functions,Spatial Functions>> requirements class specifies requirements for servers that support a richer set of spatial comparison functions. The list of additional spatial comparison functions that must be supported is:
 

--- a/cql2/standard/clause_7_enhanced.adoc
+++ b/cql2/standard/clause_7_enhanced.adoc
@@ -252,7 +252,7 @@ BBOX(160.6,-55.95,-170,-25.89)
 
 ==== Spatial Functions
 
-In this conformance class, the only required spatial comparison function is _intersects_ and the only required spatial data types are point and BBox. Additional spatial comparison functions and spatial data types are specified in the <<rc_spatial-functions,Spatial Functions>> requirements class.
+In this conformance class, the only required spatial comparison function is _intersects_ and the only required spatial literals are point and BBox. Additional spatial literals are specified in the <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>> requirements class and additional spatial comparison functions are specified in the <<rc_spatial-functions,Spatial Functions>> requirements class.
 
 include::requirements/basic-spatial-functions/REQ_spatial-predicate.adoc[]
 
@@ -290,16 +290,16 @@ Note that the values of the `filter-crs` and `filter` parameters have not been p
 ====
 
 [[basic-spatial-functions-plus]]
-=== Requirements Class "Basic Spatial Functions with additional Spatial Data Types"
+=== Requirements Class "Basic Spatial Functions with additional Spatial Literals"
 
 include::requirements/requirements_class_basic-spatial-functions-plus.adoc[]
 
-This requirements class is similar to the <<basic-spatial-functions,Basic Spatial Functions>> requirements class except it removes the restrictions on the spatial data types that can participate in the expression.
+This requirements class is similar to the <<basic-spatial-functions,Basic Spatial Functions>> requirements class except it removes the restrictions on the spatial literals that can participate in the expression.
 
 [[additional-spatial-data-types]]
 ==== Additional spatial data types and literal values
 
-In addition to the spatial types listed in the <<basic-spatial-functions,Basic Spatial Functions>> requirements class (i.e. "Point", "BBox"), this requirements class allows the following additional spatial data types (part of rule `spatialInstance`):
+In addition to the spatial types listed in the <<basic-spatial-functions,Basic Spatial Functions>> requirements class (i.e. "Point", "BBox"), this requirements class allows the following Spatial Literals (part of rule `spatialInstance`):
 
 * "LineString": a curve with linear interpolation between the vertices;
 * "Polygon": a planar surface bounded by closed line strings;

--- a/cql2/standard/requirements/cql2-json/REQ_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/requirements/cql2-json/REQ_basic-spatial-functions-plus.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-json/basic-spatial-functions-plus* 
-^|Condition |Server implements requirements class <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
+^|Condition |Server implements requirements class <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>>
 ^|A |The server SHALL be able to parse and evaluate filter expressions encoded as JSON that use the following schema components:
 
 * "#/$defs/spatialPredicate" where property "op" has the value "s_intersects"

--- a/cql2/standard/requirements/cql2-text/REQ_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/requirements/cql2-text/REQ_basic-spatial-functions-plus.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql2-text/basic-spatial-functions-plus*
-^|Condition |Server implements requirements class <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>>
-^|A |The server SHALL support be able to parse all spatial instances encoded as a text string that validate against the BNF production fragments identified in the <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Data Types>> requirements class.
+^|Condition |Server implements requirements class <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>>
+^|A |The server SHALL support be able to parse all spatial instances encoded as a text string that validate against the BNF production fragments identified in the <<rc_basic-spatial-functions-plus,Basic Spatial Functions with additional Spatial Literals>> requirements class.
 ^|B |The server SHALL support spatial literals with coordinates in a 2D or 3D CRS, independent of including the `Z` or not in the value.
 |===

--- a/cql2/standard/requirements/requirements_class_basic-spatial-functions-plus.adoc
+++ b/cql2/standard/requirements/requirements_class_basic-spatial-functions-plus.adoc
@@ -4,7 +4,6 @@
 2+|*Requirements Class*
 2+|http://www.opengis.net/spec/cql2/1.0/req/basic-spatial-functions-plus
 |Target type |Servers that evaluate filter expressions
-|Dependency |<<rc_basic-cql2,Requirements Class "Basic CQL2">>
 |Dependency |<<rc_basic-spatial-functions,Requirements Class "Basic Spatial Functions">>
 |Dependency |<<ogc06-103r4,OGC Simple feature access - Part 1: Common architecture, Architecture>>
 |===

--- a/cql2/standard/requirements/requirements_class_cql2-json.adoc
+++ b/cql2/standard/requirements/requirements_class_cql2-json.adoc
@@ -10,7 +10,7 @@
 |Conditional Dependency |<<rc_case-insensitive-comparison,Requirements Class "Case-insensitive Comparisons">>
 |Conditional Dependency |<<rc_accent-insensitive-comparison,Requirements Class "Accent-insensitive Comparisons">>
 |Conditional Dependency |<<rc_basic-spatial-functions,Requirements Class "Basic Spatial Functions">>
-|Conditional Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Data Types">>
+|Conditional Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Literals">>
 |Conditional Dependency |<<rc_spatial-functions,Requirements Class "Spatial Functions">>
 |Conditional Dependency |<<rc_temporal-functions,Requirements Class "Temporal Functions">>
 |Conditional Dependency |<<rc_array-functions,Requirements Class "Array Functions">>

--- a/cql2/standard/requirements/requirements_class_cql2-text.adoc
+++ b/cql2/standard/requirements/requirements_class_cql2-text.adoc
@@ -10,7 +10,7 @@
 |Conditional Dependency |<<rc_case-insensitive-comparison,Requirements Class "Case-insensitive Comparisons">>
 |Conditional Dependency |<<rc_accent-insensitive-comparison,Requirements Class "Accent-insensitive Comparisons">>
 |Conditional Dependency |<<rc_basic-spatial-functions,Requirements Class "Basic Spatial Functions">>
-|Conditional Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Data Types">>
+|Conditional Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Literals">>
 |Conditional Dependency |<<rc_spatial-functions,Requirements Class "Spatial Functions">>
 |Conditional Dependency |<<rc_temporal-functions,Requirements Class "Temporal Functions">>
 |Conditional Dependency |<<rc_array-functions,Requirements Class "Array Functions">>

--- a/cql2/standard/requirements/requirements_class_spatial-functions.adoc
+++ b/cql2/standard/requirements/requirements_class_spatial-functions.adoc
@@ -5,5 +5,5 @@
 2+|http://www.opengis.net/spec/cql2/1.0/req/spatial-functions
 |Target type |Servers that evaluate filter expressions
 |Dependency |<<rc_basic-spatial-functions,Requirements Class "Basic Spatial Functions">>
-|Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Data Types">>
+|Dependency |<<rc_basic-spatial-functions-plus,Requirements Class "Basic Spatial Functions with additional Spatial Literals">>
 |===


### PR DESCRIPTION
As discussed in the SWG call today, the `basic-spatial-functions` requirements class does not restrict the spatial data types that may be used in a property, it only restricts the literal values. The `basic-spatial-functions-plus` requirements class supports more literal values. It would be clearer to use "spatial literals" in some cases where currently "spatial data types" is used.