### PR TITLE
Register the "ogc-client" library as a client implementation

### DIFF
--- a/implementations/README.adoc
+++ b/implementations/README.adoc
@@ -195,6 +195,14 @@ The columns for each part list the conformance classes of the standard that the 
 | `filter`, `features-filter`, `cql-text`, `cql-json`
 | -
 | michaelkeller03 [at] gmail.com
+
+
+| link:clients/ogc-client.md[ogc-client]
+| `core`, `geojson`
+| `crs`
+| -
+| -
+| olivia.guyot [at] camptocamp
 |===
 
 ### Clients supporting GeoJSON

--- a/implementations/clients/ogc-client.md
+++ b/implementations/clients/ogc-client.md
@@ -12,7 +12,7 @@ Supported protocols are:
 ## How to use it
 
 The `OgcApiEndpoint` class lets us interact with an OGC API compliant endpoint in various ways. Since most operations in an OGC API endpoint revolves around doing requests to various linked addresses,
-this class offers an abstraction pased on simple promises.
+this class offers an abstraction based on simple promises.
 
 For instance, to get a list of collections:
 
@@ -21,7 +21,7 @@ const endpoint = new OgcApiEndpoint('https://my.endpoint.org/ogcapi');
 console.log(await endpoint.allCollections);
 ```
 
-More detailed information on collection can be fetched like so:
+More detailed information on a single collection can be fetched like so:
 
 ```js
 const collection = await endpoint.getCollectionInfo('city-roads');

--- a/implementations/clients/ogc-client.md
+++ b/implementations/clients/ogc-client.md
@@ -1,0 +1,52 @@
+# ogc-client
+
+[ogc-client](https://github.com/camptocamp/ogc-client) is a Typescript library that offers useful APIs on top of various OGC protocols, including OGC API.
+
+Supported protocols are:
+
+* WMS - Web Map Service
+* WFS - Web Feature Service
+* WMTS - Web Map Tile Service
+* OGC API (Records and Features)
+
+## How to use it
+
+The `OgcApiEndpoint` class lets us interact with an OGC API compliant endpoint in various ways. Since most operations in an OGC API endpoint revolves around doing requests to various linked addresses,
+this class offers an abstraction pased on simple promises.
+
+For instance, to get a list of collections:
+
+```js
+const endpoint = new OgcApiEndpoint('https://my.endpoint.org/ogcapi');
+console.log(await endpoint.allCollections);
+```
+
+More detailed information on collection can be fetched like so:
+
+```js
+const collection = await endpoint.getCollectionInfo('city-roads');
+console.log(collection.itemCount);
+```
+
+To read items in a collection, the `/items` endpoint can be exploited like so:
+
+```js
+const itemsUrl = await endpoint.getCollectionItemsUrl(
+  'city-roads',
+  {
+    asJson: true,
+    limit: 10,
+    offset: 30
+  }
+);
+fetch(itemsUrl).then(resp => resp.json()).then(...)
+```
+
+Items can also be fetched in bulk, often using more diverse formats:
+
+```js
+const flatgeobufUrl = collection.bulkDownloadLinks['application/flatgeobuf'];
+fetch(flatgeobufUrl).then(resp => resp.arrayBuffer()).then(...)
+```
+
+See https://camptocamp.github.io/ogc-client/#/api for more details on the API of ogc-client.


### PR DESCRIPTION
This PR simply registers [ogc-client](https://github.com/camptocamp/ogc-client) as a client implementation. Thank you!