### PR TITLE
fix link schema

### DIFF
--- a/core/openapi/ogcapi-features-1.yaml
+++ b/core/openapi/ogcapi-features-1.yaml
@@ -428,6 +428,7 @@ components:
       type: object
       required:
         - href
+        - rel
       properties:
         href:
           type: string


### PR DESCRIPTION
`rel` was not required in core/openapi/ogcapi-features-1.yaml