### PR TITLE
provide schemas for both OpenAPI v3.0 and v3.1

### DIFF
--- a/core/examples/README.md
+++ b/core/examples/README.md
@@ -3,6 +3,6 @@
 The sub-folders contain examples of responses of implementations of 
 OGC API - Features - Part 1: Core.
 
-* [OpenAPI examples](openapi)
+* [OpenAPI 3.1 examples](openapi)
 * [JSON/GeoJSON examples](json)
 * [XML/GML examples](xml)

--- a/core/examples/openapi/README.md
+++ b/core/examples/openapi/README.md
@@ -2,13 +2,15 @@
 
 This folder includes two complete examples of an OpenAPI definition for a Web API implementing OGC API Features (the Core, HTML, GeoJSON and OpenAPI 3.1 conformance classes).
 
-The [first example (ogcapi-features-1-example1.yaml)](ogcapi-features-1-example1.yaml) is a generic example that uses path parameters to describe all feature collections and all features. This OpenAPI definition does not provide any details on the collections or the feature content. This information is only available from the feature collection metadata. The API is also on [SwaggerHub](https://app.swaggerhub.com/apis/cportele/ogcapi-features-1-example1/1.0.0).
+The [first example (ogcapi-features-1-example1.yaml)](ogcapi-features-1-example1.yaml) is a generic example that uses path parameters to describe all feature collections and all features. This OpenAPI definition does not provide any details on the collections or the feature content. This information is only available from the feature collection metadata.
 
-The [second example (ogcapi-features-1-example2.yaml)](ogcapi-features-1-example2.yaml) does not use a path parameter for the collections and explicitly provides information about the feature collection 'buildings' (paths /collections/buildings etc.), the schema of the building features (schema buildingGeoJSON) and a filter parameter for building features (parameter function). The API is also on [SwaggerHub](https://app.swaggerhub.com/apis/cportele/ogcapi-features-1-example2/1.0.0).
+The [second example (ogcapi-features-1-example2.yaml)](ogcapi-features-1-example2.yaml) does not use a path parameter for the collections and explicitly provides information about the feature collection 'buildings' (paths /collections/buildings etc.), the schema of the building features (schema buildingGeoJSON) and a filter parameter for building features (parameter function).
 
 NOTE: If you want to compile an OpenAPI definition example with all definitions in a single file, follow these steps:
 
 * Open the example file (example 1 or example 2).
-* Open the file with all building blocks ([ogcapi-features-1.yaml](https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml)) and delete the top level members "openapi", "info", "servers", and "tags". Add the remaining content, i.e. the "components" member, at the end of the example file.
-* Replace all occurances of "https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml" with "" (empty string).
+* Open the file with all OpenAPI 3.1 building blocks ([ogcapi-features-1-oas31.yaml](https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml)) and delete the top level members "openapi", "info", "servers", and "tags". Add the remaining content, i.e. the "components" member, at the end of the example file.
+* Replace all occurances of "https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml" with "" (empty string).
 * Save the OpenAPI definition.
+
+For OpenAPI 3.0 use ([ogcapi-features-1-oas30.yaml](https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml)) instead.

--- a/core/examples/openapi/ogcapi-features-1-example1.yaml
+++ b/core/examples/openapi/ogcapi-features-1-example1.yaml
@@ -46,9 +46,9 @@ paths:
       operationId: getLandingPage
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/LandingPage'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/LandingPage'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/conformance':
     get:
       tags:
@@ -60,9 +60,9 @@ paths:
       operationId: getConformanceDeclaration
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ConformanceDeclaration'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ConformanceDeclaration'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections':
     get:
       tags:
@@ -71,9 +71,9 @@ paths:
       operationId: getCollections
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Collections'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/Collections'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections/{collectionId}':
     get:
       tags:
@@ -82,14 +82,14 @@ paths:
         describe the feature collection with id `collectionId`
       operationId: describeCollection
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/collectionId'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Collection'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/Collection'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections/{collectionId}/items':
     get:
       tags:
@@ -105,19 +105,19 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeatures
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/limit'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/bbox'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/datetime'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/limit'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/bbox'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/datetime'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Features'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/Features'
         '400':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/InvalidParameter'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections/{collectionId}/items/{featureId}':
     get:
       tags:
@@ -130,12 +130,12 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeature
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/featureId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/featureId'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Feature'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/Feature'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'

--- a/core/examples/openapi/ogcapi-features-1-example1.yaml
+++ b/core/examples/openapi/ogcapi-features-1-example1.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
   title: "A sample API conforming to the draft standard OGC API - Features - Part 1: Core"
   version: '1.0.0'

--- a/core/examples/openapi/ogcapi-features-1-example2.yaml
+++ b/core/examples/openapi/ogcapi-features-1-example2.yaml
@@ -43,9 +43,9 @@ paths:
       operationId: getLandingPage
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/LandingPage'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/LandingPage'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/conformance':
     get:
       tags:
@@ -57,9 +57,9 @@ paths:
       operationId: getConformanceDeclaration
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ConformanceDeclaration'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ConformanceDeclaration'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections':
     get:
       tags:
@@ -68,9 +68,9 @@ paths:
       operationId: getCollections
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Collections'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/Collections'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections/buildings':
     get:
       tags:
@@ -80,9 +80,9 @@ paths:
       operationId: describeCollection
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Collection'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/Collection'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections/buildings/items':
     get:
       tags:
@@ -94,9 +94,9 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeatures
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/limit'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/bbox'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/datetime'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/limit'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/bbox'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/datetime'
         - $ref: '#/components/parameters/function'
       responses:
         '200':
@@ -167,9 +167,9 @@ paths:
               schema:
                 type: string
         '400':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/InvalidParameter'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
   '/collections/buildings/items/{featureId}':
     get:
       tags:
@@ -181,7 +181,7 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeature
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/featureId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/parameters/featureId'
       responses:
         '200':
           description: |-
@@ -221,9 +221,9 @@ paths:
               schema:
                 type: string
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/responses/ServerError'
 components:
   parameters:
     function:
@@ -261,13 +261,13 @@ components:
         links:
           type: array
           items:
-            $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/link'
+            $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/schemas/link'
         timeStamp:
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/timeStamp'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/schemas/timeStamp'
         numberMatched:
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/numberMatched'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/schemas/numberMatched'
         numberReturned:
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/numberReturned'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/schemas/numberReturned'
     buildingGeoJSON:
       type: object
       required:
@@ -280,7 +280,7 @@ components:
           enum:
             - Feature
         geometry:
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/geometryGeoJSON'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/schemas/geometryGeoJSON'
         properties:
           oneOf:
             - type: null
@@ -307,4 +307,4 @@ components:
         links:
           type: array
           items:
-            $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/link'
+            $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas31.yaml#/components/schemas/link'

--- a/core/examples/openapi/ogcapi-features-1-example2.yaml
+++ b/core/examples/openapi/ogcapi-features-1-example2.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
   title: "A sample API conforming to the draft standard OGC API - Features - Part 1: Core"
   version: '1.0.0'

--- a/core/openapi/README.md
+++ b/core/openapi/README.md
@@ -1,0 +1,7 @@
+# OpenAPI descriptions of API building blocks
+
+There are two aspects of the use of [OpenAPI](https://openapis.org) in OGC API Features.
+
+1. OpenAPI is used to define the API building blocks that are specified by OGC API Features. That is, OpenAPI components are used to normatively specify characteristics of the API building blocks (content schemas, query or path parameters, etc.). In version 1.0 of Part 1 (Core) OpenAPI 3.0 has been used. Starting with version 1.1, OpenAPI 3.1 will be used to document the API building blocks in OGC API Features standards.
+
+2. OpenAPI descriptions can be used by API instances to document the API. There will be separate requirements classes for OpenAPI 3.0 and OpenAPI 3.1 in OGC API - Features - Part 1: Core 1.1. To support reuse of the API building blocks the OpenAPI components are maintained for both versions of OpenAPI ([ogcapi-features-1-oas30.yaml](ogcapi-features-1-oas30.yaml) and [ogcapi-features-1-oas31.yaml](ogcapi-features-1-oas31.yaml)). The differences are small ("null" is a type in OpenAPI 3.1 vs the use of "nullable" as an attribute of a property in OpenAPI 3.0; in addition, "const" can be used in OpenAPI 3.1 for enumerations with a single value).

--- a/core/openapi/ogcapi-features-1-oas30.yaml
+++ b/core/openapi/ogcapi-features-1-oas30.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.0.4
 info:
   title: "Building Blocks specified in OGC API - Features - Part 1: Core"
   description: |-

--- a/core/openapi/ogcapi-features-1-oas30.yaml
+++ b/core/openapi/ogcapi-features-1-oas30.yaml
@@ -1,17 +1,17 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: "Building Blocks specified in OGC API - Features - Part 1: Core"
   description: |-
     Common components used in the
     [OGC standard "OGC API - Features - Part 1: Core"](https://docs.ogc.org/is/17-069r5/17-069r5.html).
 
-    OGC API - Features - Part 1: Core 1.0 is an OGC Standard.
+    OGC API - Features - Part 1: Core 1.1 is an OGC Standard.
     Copyright (c) 2024 Open Geospatial Consortium.
     To obtain additional rights of use, visit https://www.ogc.org/legal/ .
 
     This document is also available on
-    [OGC](https://schemas.opengis.net/ogcapi/features/part1/1.1/openapi/ogcapi-features-1.yaml).
-  version: '1.0.0'
+    [OGC](https://schemas.opengis.net/ogcapi/features/part1/1.1/openapi/ogcapi-features-1-oas30.yaml).
+  version: '1.1.0'
   contact:
     name: Clemens Portele
     email: portele@interactive-instruments.de
@@ -151,7 +151,7 @@ components:
           example:
             - href: https://data.example.com/buildings
               rel: item
-            - href: http://example.com/concepts/buildings.html
+            - href: https://example.com/concepts/buildings.html
               rel: describedby
               type: text/html
         linkTemplates:
@@ -303,10 +303,9 @@ components:
                 minItems: 2
                 maxItems: 2
                 items:
-                  oneOf:
-                    - type: string
-                      format: date-time
-                    - type: null  
+                  type: string
+                  format: date-time
+                  nullable: true
                 example:
                   - '2011-11-11T12:22:11Z'
                   - null
@@ -357,13 +356,10 @@ components:
           enum:
             - Feature
         geometry:
-          oneOf:
-            - type: null
-            - $ref: "#/components/schemas/geometryGeoJSON"
+          $ref: "#/components/schemas/geometryGeoJSON"
         properties:
-          type: 
-            - object
-            - null  
+          type: object
+          nullable: true
         id:
           oneOf:
             - type: string
@@ -381,6 +377,7 @@ components:
       - $ref: "#/components/schemas/polygonGeoJSON"
       - $ref: "#/components/schemas/multipolygonGeoJSON"
       - $ref: "#/components/schemas/geometrycollectionGeoJSON"
+      nullable: true
     geometrycollectionGeoJSON:
       type: object
       required:
@@ -605,23 +602,23 @@ components:
             title: Buildings in Bonn
             description: Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.
             links:
-              - href: 'http://data.example.org/'
+              - href: 'https://data.example.org/'
                 rel: self
                 type: application/json
                 title: this document
-              - href: 'http://data.example.org/api'
+              - href: 'https://data.example.org/api'
                 rel: service-desc
                 type: application/vnd.oai.openapi+json;version=3.0
                 title: the API definition
-              - href: 'http://data.example.org/api.html'
+              - href: 'https://data.example.org/api.html'
                 rel: service-doc
                 type: text/html
                 title: the API documentation
-              - href: 'http://data.example.org/conformance'
+              - href: 'https://data.example.org/conformance'
                 rel: conformance
                 type: application/json
                 title: OGC API conformance classes implemented by this server
-              - href: 'http://data.example.org/collections'
+              - href: 'https://data.example.org/collections'
                 rel: data
                 type: application/json
                 title: Information about the feature collections
@@ -672,19 +669,19 @@ components:
             $ref: '#/components/schemas/collections'
           example:
             links:
-              - href: 'http://data.example.org/collections.json'
+              - href: 'https://data.example.org/collections.json'
                 rel: self
                 type: application/json
                 title: this document
-              - href: 'http://data.example.org/collections.html'
+              - href: 'https://data.example.org/collections.html'
                 rel: alternate
                 type: text/html
                 title: this document as HTML
-              - href: 'http://schemas.example.org/1.0/buildings.xsd'
+              - href: 'https://schemas.example.org/1.0/buildings.xsd'
                 rel: describedby
                 type: application/xml
                 title: GML application schema for Acme Corporation building data
-              - href: 'http://download.example.org/buildings.gpkg'
+              - href: 'https://download.example.org/buildings.gpkg'
                 rel: enclosure
                 type: application/geopackage+sqlite3
                 title: Bulk download (GeoPackage)
@@ -705,11 +702,11 @@ components:
                       - - '2010-02-15T12:34:56Z'
                         - null
                 links:
-                  - href: 'http://data.example.org/collections/buildings/items'
+                  - href: 'https://data.example.org/collections/buildings/items'
                     rel: items
                     type: application/geo+json
                     title: Buildings
-                  - href: 'http://data.example.org/collections/buildings/items.html'
+                  - href: 'https://data.example.org/collections/buildings/items.html'
                     rel: items
                     type: text/html
                     title: Buildings
@@ -758,11 +755,11 @@ components:
                   - - '2010-02-15T12:34:56Z'
                     - null
             links:
-              - href: 'http://data.example.org/collections/buildings/items'
+              - href: 'https://data.example.org/collections/buildings/items'
                 rel: items
                 type: application/geo+json
                 title: Buildings
-              - href: 'http://data.example.org/collections/buildings/items.html'
+              - href: 'https://data.example.org/collections/buildings/items.html'
                 rel: items
                 type: text/html
                 title: Buildings

--- a/core/openapi/ogcapi-features-1-oas31.yaml
+++ b/core/openapi/ogcapi-features-1-oas31.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
   title: "Building Blocks specified in OGC API - Features - Part 1: Core"
   description: |-

--- a/core/openapi/ogcapi-features-1-oas31.yaml
+++ b/core/openapi/ogcapi-features-1-oas31.yaml
@@ -329,8 +329,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - FeatureCollection
+          const: FeatureCollection
         features:
           type: array
           items:
@@ -354,8 +353,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - Feature
+          const: Feature
         geometry:
           oneOf:
             - type: null
@@ -365,9 +363,9 @@ components:
             - object
             - null  
         id:
-          oneOf:
-            - type: string
-            - type: integer
+          type:
+            - string
+            - integer
         links:
           type: array
           items:
@@ -389,8 +387,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - GeometryCollection
+          const: GeometryCollection
         geometries:
           type: array
           items:
@@ -418,8 +415,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - LineString
+          const: LineString
         coordinates:
           type: array
           minItems: 2
@@ -478,8 +474,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - MultiLineString
+          const: MultiLineString
         coordinates:
           type: array
           items:
@@ -498,8 +493,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - MultiPoint
+          const: MultiPoint
         coordinates:
           type: array
           items:
@@ -515,8 +509,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - MultiPolygon
+          const: MultiPolygon
         coordinates:
           type: array
           items:
@@ -556,8 +549,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - Point
+          const: Point
         coordinates:
           type: array
           minItems: 2
@@ -571,8 +563,7 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - Polygon
+          const: Polygon
         coordinates:
           type: array
           items:

--- a/core/openapi/ogcapi-features-1-oas31.yaml
+++ b/core/openapi/ogcapi-features-1-oas31.yaml
@@ -1,0 +1,910 @@
+openapi: 3.1.0
+info:
+  title: "Building Blocks specified in OGC API - Features - Part 1: Core"
+  description: |-
+    Common components used in the
+    [OGC standard "OGC API - Features - Part 1: Core"](https://docs.ogc.org/is/17-069r5/17-069r5.html).
+
+    OGC API - Features - Part 1: Core 1.1 is an OGC Standard.
+    Copyright (c) 2024 Open Geospatial Consortium.
+    To obtain additional rights of use, visit https://www.ogc.org/legal/ .
+
+    This document is also available on
+    [OGC](https://schemas.opengis.net/ogcapi/features/part1/1.1/openapi/ogcapi-features-1-oas31.yaml).
+  version: '1.1.0'
+  contact:
+    name: Clemens Portele
+    email: portele@interactive-instruments.de
+  license:
+    name: OGC License
+    url: 'https://www.ogc.org/legal/'
+components:
+  parameters:
+    bbox:
+      name: bbox
+      in: query
+      description: |-
+        Only features that have a geometry that intersects the bounding box are selected.
+        The bounding box is provided as four or six numbers, depending on whether the
+        coordinate reference system includes a vertical axis (height or depth):
+
+        * Lower left corner, coordinate axis 1
+        * Lower left corner, coordinate axis 2
+        * Minimum value, coordinate axis 3 (optional)
+        * Upper right corner, coordinate axis 1
+        * Upper right corner, coordinate axis 2
+        * Maximum value, coordinate axis 3 (optional)
+
+        If the value consists of four numbers, the coordinate reference system is
+        WGS 84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84)
+        unless a different coordinate reference system is specified in the parameter `bbox-crs`.
+
+        If the value consists of six numbers, the coordinate reference system is WGS 84 
+        longitude/latitude/ellipsoidal height (http://www.opengis.net/def/crs/OGC/0/CRS84h)
+        unless a different coordinate reference system is specified in the parameter `bbox-crs`.
+
+        The query parameter `bbox-crs` is specified in OGC API - Features - Part 2: Coordinate 
+        Reference Systems by Reference.
+
+        For WGS 84 longitude/latitude the values are in most cases the sequence of
+        minimum longitude, minimum latitude, maximum longitude and maximum latitude.
+        However, in cases where the box spans the antimeridian the first value
+        (west-most box edge) is larger than the third or fourth value (east-most box edge).
+
+        If the vertical axis is included, the third and the sixth number are
+        the bottom and the top of the 3-dimensional bounding box.
+
+        If a feature has multiple spatial geometry properties, it is the decision of the
+        server whether only a single spatial geometry property is used to determine
+        the extent or all relevant geometries.
+      required: false
+      schema:
+        type: array
+        oneOf:
+        - minItems: 4
+          maxItems: 4
+        - minItems: 6
+          maxItems: 6
+        items:
+          type: number
+      style: form
+      explode: false
+    collectionId:
+      name: collectionId
+      in: path
+      description: local identifier of a collection
+      required: true
+      schema:
+        type: string
+    datetime:
+      name: datetime
+      in: query
+      description: |-
+        Either a date-time or an interval. Date and time expressions adhere to RFC 3339. 
+        Intervals may be bounded or half-bounded (double-dots at start or end).
+
+        Examples:
+
+        * A date-time: "2018-02-12T23:20:50Z"
+        * A bounded interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+        * Half-bounded intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+
+        Only features that have a temporal property that intersects the value of
+        `datetime` are selected.
+
+        If a feature has multiple temporal properties, it is the decision of the
+        server whether only a single temporal property is used to determine
+        the extent or all relevant temporal properties.
+      required: false
+      schema:
+        type: string
+      style: form
+      explode: false
+    featureId:
+      name: featureId
+      in: path
+      description: local identifier of a feature
+      required: true
+      schema:
+        type: string
+    limit:
+      name: limit
+      in: query
+      description: |-
+        The optional limit parameter limits the number of items that are presented in the response document.
+
+        Only items are counted that are on the first level of the collection in the response document.
+        Nested objects contained within the explicitly requested items shall not be counted.
+
+        Minimum = 1. Maximum = 10000. Default = 10.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 10000
+        default: 100
+      style: form
+      explode: false
+  schemas:
+    collection:
+      type: object
+      required:
+        - id
+        - links
+      properties:
+        id:
+          description: identifier of the collection used, for example, in URIs
+          type: string
+          example: address
+        title:
+          description: human readable title of the collection
+          type: string
+          example: address
+        description:
+          description: a description of the features in the collection
+          type: string
+          example: An address.
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+          example:
+            - href: https://data.example.com/buildings
+              rel: item
+            - href: https://example.com/concepts/buildings.html
+              rel: describedby
+              type: text/html
+        linkTemplates:
+          type: array
+          items:
+            $ref: "#/components/schemas/linkTemplate"
+        extent:
+          $ref: "#/components/schemas/extent"
+        itemType:
+          description: indicator about the type of the items in the collection (the default value is 'feature').
+          type: string
+          default: feature
+        crs:
+          description: the list of coordinate reference systems supported by the service
+          type: array
+          items:
+            type: string
+          default:
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+          example:
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/EPSG/0/4326
+    collections:
+      type: object
+      required:
+        - links
+        - collections
+      properties:
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+        collections:
+          type: array
+          items:
+            $ref: "#/components/schemas/collection"
+    confClasses:
+      type: object
+      required:
+        - conformsTo
+      properties:
+        conformsTo:
+          type: array
+          items:
+            type: string
+    exception:
+      type: object
+      description: |-
+        Information about the exception: an error code plus an optional description.
+      required:
+        - code
+      properties:
+        code:
+          type: string
+        description:
+          type: string
+    extent:
+      type: object
+      description: |-
+        The extent of the features in the collection. In the Core only spatial and temporal
+        extents are specified. Extensions may add additional members to represent other
+        extents, for example, thermal or pressure ranges.
+      properties:
+        spatial:
+          description: |-
+            The spatial extent of the features in the collection.
+          type: object
+          properties:
+            bbox:
+              description: |-
+                One or more bounding boxes that describe the spatial extent of the dataset.
+                In the Core only a single bounding box is supported. Extensions may support
+                additional areas. If multiple areas are provided, the union of the bounding
+                boxes describes the spatial extent.
+              type: array
+              minItems: 1
+              items:
+                description: |-
+                  Each bounding box is provided as four or six numbers, depending on
+                  whether the coordinate reference system includes a vertical axis
+                  (height or depth):
+
+                  * Lower left corner, coordinate axis 1
+                  * Lower left corner, coordinate axis 2
+                  * Minimum value, coordinate axis 3 (optional)
+                  * Upper right corner, coordinate axis 1
+                  * Upper right corner, coordinate axis 2
+                  * Maximum value, coordinate axis 3 (optional)
+
+                  The coordinate reference system of the values is WGS 84 longitude/latitude
+                  (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate
+                  reference system is specified in `crs`.
+
+                  For WGS 84 longitude/latitude the values are in most cases the sequence of
+                  minimum longitude, minimum latitude, maximum longitude and maximum latitude.
+                  However, in cases where the box spans the antimeridian the first value
+                  (west-most box edge) is larger than the third or fourth value (east-most box edge).
+
+                  If the vertical axis is included, the third and the sixth number are
+                  the bottom and the top of the 3-dimensional bounding box.
+
+                  If a feature has multiple spatial geometry properties, it is the decision of the
+                  server whether only a single spatial geometry property is used to determine
+                  the extent or all relevant geometries.
+                type: array
+                oneOf:
+                - minItems: 4
+                  maxItems: 4
+                - minItems: 6
+                  maxItems: 6
+                items:
+                  type: number
+                example:
+                  - -180
+                  - -90
+                  - 180
+                  - 90
+            crs:
+              description: |-
+                Coordinate reference system of the coordinates in the spatial extent
+                (property `bbox`). The default reference system is WGS 84 longitude/latitude.
+                In the Core this is the only supported coordinate reference system.
+                Extensions may support additional coordinate reference systems and add
+                additional enum values.
+              type: string
+              enum:
+                - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+              default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+        temporal:
+          description: |-
+            The temporal extent of the features in the collection.
+          type: object
+          properties:
+            interval:
+              description: |-
+                One or more time intervals that describe the temporal extent of the dataset.
+                The value `null` is supported and indicates an unbounded interval end.
+                In the Core only a single time interval is supported. Extensions may support
+                multiple intervals. If multiple intervals are provided, the union of the
+                intervals describes the temporal extent.
+              type: array
+              minItems: 1
+              items:
+                description: |-
+                  Begin and end times of the time interval. The timestamps are in the
+                  temporal coordinate reference system specified in `trs`. By default
+                  this is the Gregorian calendar.
+                type: array
+                minItems: 2
+                maxItems: 2
+                items:
+                  oneOf:
+                    - type: string
+                      format: date-time
+                    - type: null  
+                example:
+                  - '2011-11-11T12:22:11Z'
+                  - null
+            trs:
+              description: |-
+                Coordinate reference system of the coordinates in the temporal extent
+                (property `interval`). The default reference system is the Gregorian calendar.
+                In the Core this is the only supported temporal coordinate reference system.
+                Extensions may support additional temporal coordinate reference systems and add
+                additional enum values.
+              type: string
+              enum:
+                - 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+              default: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+    featureCollectionGeoJSON:
+      type: object
+      required:
+        - type
+        - features
+      properties:
+        type:
+          type: string
+          enum:
+            - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: "#/components/schemas/featureGeoJSON"
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+        timeStamp:
+          $ref: "#/components/schemas/timeStamp"
+        numberMatched:
+          $ref: "#/components/schemas/numberMatched"
+        numberReturned:
+          $ref: "#/components/schemas/numberReturned"
+    featureGeoJSON:
+      type: object
+      required:
+        - type
+        - geometry
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - Feature
+        geometry:
+          oneOf:
+            - type: null
+            - $ref: "#/components/schemas/geometryGeoJSON"
+        properties:
+          type: 
+            - object
+            - null  
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+    geometryGeoJSON:
+      oneOf:
+      - $ref: "#/components/schemas/pointGeoJSON"
+      - $ref: "#/components/schemas/multipointGeoJSON"
+      - $ref: "#/components/schemas/linestringGeoJSON"
+      - $ref: "#/components/schemas/multilinestringGeoJSON"
+      - $ref: "#/components/schemas/polygonGeoJSON"
+      - $ref: "#/components/schemas/multipolygonGeoJSON"
+      - $ref: "#/components/schemas/geometrycollectionGeoJSON"
+    geometrycollectionGeoJSON:
+      type: object
+      required:
+        - type
+        - geometries
+      properties:
+        type:
+          type: string
+          enum:
+            - GeometryCollection
+        geometries:
+          type: array
+          items:
+            $ref: "#/components/schemas/geometryGeoJSON"
+    landingPage:
+      type: object
+      required:
+        - links
+      properties:
+        title:
+          type: string
+          example: Buildings in Bonn
+        description:
+          type: string
+          example: Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+    linestringGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - LineString
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
+    link:
+      type: object
+      required:
+        - href
+        - rel
+      properties:
+        href:
+          type: string
+          example: https://data.example.com/buildings/123
+        rel:
+          type: string
+          example: alternate
+        type:
+          type: string
+          example: application/geo+json
+        hreflang:
+          type: string
+          example: en
+        title:
+          type: string
+          example: Trierer Strasse 70, 53115 Bonn
+        length:
+          type: integer
+    linkTemplate:
+      type: object
+      required:
+        - uriTemplate
+        - rel
+      properties:
+        uriTemplate:
+          type: string
+          example: https://data.example.org/collections/buildings/items/{featureId}
+        rel:
+          type: string
+        title:
+          type: string
+          example: Link template for building features
+        type:
+          type: string
+          example: application/geo+json
+        varBase:
+          type: string
+    multilinestringGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiLineString
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: array
+              minItems: 2
+              items:
+                type: number
+    multipointGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
+    multipolygonGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPolygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              type: array
+              minItems: 4
+              items:
+                type: array
+                minItems: 2
+                items:
+                  type: number
+    numberMatched:
+      description: |-
+        The number of features of the feature type that match the selection
+        parameters like `bbox`.
+      type: integer
+      minimum: 0
+      example: 127
+    numberReturned:
+      description: |-
+        The number of features in the feature collection.
+
+        A server may omit this information in a response, if the information
+        about the number of features is not known or difficult to compute.
+
+        If the value is provided, the value shall be identical to the number
+        of items in the "features" array.
+      type: integer
+      minimum: 0
+      example: 10
+    pointGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: number
+    polygonGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 4
+            items:
+              type: array
+              minItems: 2
+              items:
+                type: number
+    timeStamp:
+      description: This property indicates the time and date when the response was generated.
+      type: string
+      format: date-time
+      example: '2017-08-17T08:05:32Z'
+  responses:
+    LandingPage:
+      description: |-
+        The landing page provides links to the API definition
+        (link relations `service-desc` and `service-doc`),
+        the Conformance declaration (path `/conformance`,
+        link relation `conformance`), and the Feature
+        Collections (path `/collections`, link relation
+        `data`).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/landingPage'
+          example:
+            title: Buildings in Bonn
+            description: Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.
+            links:
+              - href: 'https://data.example.org/'
+                rel: self
+                type: application/json
+                title: this document
+              - href: 'https://data.example.org/api'
+                rel: service-desc
+                type: application/vnd.oai.openapi+json;version=3.0
+                title: the API definition
+              - href: 'https://data.example.org/api.html'
+                rel: service-doc
+                type: text/html
+                title: the API documentation
+              - href: 'https://data.example.org/conformance'
+                rel: conformance
+                type: application/json
+                title: OGC API conformance classes implemented by this server
+              - href: 'https://data.example.org/collections'
+                rel: data
+                type: application/json
+                title: Information about the feature collections
+        text/html:
+          schema:
+            type: string
+    ConformanceDeclaration:
+      description: |-
+        The URIs of all conformance classes supported by the server.
+
+        To support "generic" clients that want to access multiple
+        OGC API Features implementations - and not "just" a specific
+        API / server, the server declares the conformance
+        classes it implements and conforms to.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/confClasses'
+          example:
+            conformsTo:
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.1/conf/core'
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.1/conf/oas31'
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.1/conf/html'
+              - 'http://www.opengis.net/spec/ogcapi-features-1/1.1/conf/geojson'
+        text/html:
+          schema:
+            type: string
+    Collections:
+      description: |-
+        The feature collections shared by this API.
+
+        The dataset is organized as one or more feature collections. This resource
+        provides information about and access to the collections.
+
+        The response contains the list of collections. For each collection, a link
+        to the items in the collection (path `/collections/{collectionId}/items`,
+        link relation `items`) as well as key information about the collection.
+        This information includes:
+
+        * A local identifier for the collection that is unique for the dataset;
+        * An optional list of coordinate reference systems (CRS) in which geometries may be returned by the server. The default value is a list with the default CRS (WGS 84 with axis order longitude/latitude).
+        * An optional title and description for the collection;
+        * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data;
+        * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/collections'
+          example:
+            links:
+              - href: 'https://data.example.org/collections.json'
+                rel: self
+                type: application/json
+                title: this document
+              - href: 'https://data.example.org/collections.html'
+                rel: alternate
+                type: text/html
+                title: this document as HTML
+              - href: 'https://schemas.example.org/1.0/buildings.xsd'
+                rel: describedby
+                type: application/xml
+                title: GML application schema for Acme Corporation building data
+              - href: 'https://download.example.org/buildings.gpkg'
+                rel: enclosure
+                type: application/geopackage+sqlite3
+                title: Bulk download (GeoPackage)
+                length: 472546
+            collections:
+              - id: buildings
+                title: Buildings
+                description: Buildings in the city of Bonn.
+                extent:
+                  spatial:
+                    bbox:
+                      - - 7.01
+                        - 50.63
+                        - 7.22
+                        - 50.78
+                  temporal:
+                    interval:
+                      - - '2010-02-15T12:34:56Z'
+                        - null
+                links:
+                  - href: 'https://data.example.org/collections/buildings/items'
+                    rel: items
+                    type: application/geo+json
+                    title: Buildings
+                  - href: 'https://data.example.org/collections/buildings/items.html'
+                    rel: items
+                    type: text/html
+                    title: Buildings
+                  - href: 'https://creativecommons.org/publicdomain/zero/1.0/'
+                    rel: license
+                    type: text/html
+                    title: CC0-1.0
+                  - href: 'https://creativecommons.org/publicdomain/zero/1.0/rdf'
+                    rel: license
+                    type: application/rdf+xml
+                    title: CC0-1.0
+        text/html:
+          schema:
+            type: string
+    Collection:
+      description: |-
+        Information about the feature collection with id `collectionId`.
+
+        The response contains a link to the items in the collection
+        (path `/collections/{collectionId}/items`, link relation `items`)
+        as well as key information about the collection. This information
+        includes:
+
+        * A local identifier for the collection that is unique for the dataset;
+        * An optional list of coordinate reference systems (CRS) in which geometries may be returned by the server. The default value is a list with the default CRS (WGS 84 with axis order longitude/latitude).
+        * An optional title and description for the collection;
+        * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data;
+        * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/collection'
+          example:
+            id: buildings
+            title: Buildings
+            description: Buildings in the city of Bonn.
+            extent:
+              spatial:
+                bbox:
+                  - - 7.01
+                    - 50.63
+                    - 7.22
+                    - 50.78
+              temporal:
+                interval:
+                  - - '2010-02-15T12:34:56Z'
+                    - null
+            links:
+              - href: 'https://data.example.org/collections/buildings/items'
+                rel: items
+                type: application/geo+json
+                title: Buildings
+              - href: 'https://data.example.org/collections/buildings/items.html'
+                rel: items
+                type: text/html
+                title: Buildings
+              - href: 'https://creativecommons.org/publicdomain/zero/1.0/'
+                rel: license
+                type: text/html
+                title: CC0-1.0
+              - href: 'https://creativecommons.org/publicdomain/zero/1.0/rdf'
+                rel: license
+                type: application/rdf+xml
+                title: CC0-1.0
+        text/html:
+          schema:
+            type: string
+    Features:
+      description: |-
+        The response is a document consisting of features in the collection.
+        The features included in the response are determined by the server
+        based on the query parameters of the request. To support access to
+        larger collections without overloading the client, the API supports
+        paged access with links to the next page, if more features are selected
+        that the page size.
+
+        The `bbox` and `datetime` parameter can be used to select only a
+        subset of the features in the collection (the features that are in the
+        bounding box or time interval). The `bbox` parameter matches all features
+        in the collection that are not associated with a location, too. The
+        `datetime` parameter matches all features in the collection that are
+        not associated with a time stamp or interval, too.
+
+        The `limit` parameter may be used to control the subset of the
+        selected features that should be returned in the response, the page size.
+        Each page may include information about the number of selected and
+        returned features (`numberMatched` and `numberReturned`) as well as
+        links to support paging (link relation `next`).
+      content:
+        application/geo+json:
+          schema:
+            $ref: '#/components/schemas/featureCollectionGeoJSON'
+          example:
+            type: FeatureCollection
+            links:
+              - href: 'https://data.example.com/collections/buildings/items.json'
+                rel: self
+                type: application/geo+json
+                title: this document
+              - href: 'https://data.example.com/collections/buildings/items.html'
+                rel: alternate
+                type: text/html
+                title: this document as HTML
+              - href: 'https://data.example.com/collections/buildings/items.json&offset=10&limit=2'
+                rel: next
+                type: application/geo+json
+                title: next page
+            timeStamp: '2018-04-03T14:52:23Z'
+            numberMatched: 123
+            numberReturned: 2
+            features:
+              - type: Feature
+                id: '123'
+                geometry:
+                  type: Polygon
+                  coordinates:
+                    - ...
+                properties:
+                  function: residential
+                  floors: '2'
+                  lastUpdate: '2015-08-01T12:34:56Z'
+              - type: Feature
+                id: '132'
+                geometry:
+                  type: Polygon
+                  coordinates:
+                    - ...
+                properties:
+                  function: public use
+                  floors: '10'
+                  lastUpdate: '2013-12-03T10:15:37Z'
+        text/html:
+          schema:
+            type: string
+    Feature:
+      description: |-
+        fetch the feature with id `featureId` in the feature collection
+        with id `collectionId`
+      content:
+        application/geo+json:
+          schema:
+            $ref: '#/components/schemas/featureGeoJSON'
+          example:
+            type: Feature
+            links:
+              - href: 'https://data.example.com/id/building/123'
+                rel: canonical
+                title: canonical URI of the building
+              - href: 'https://data.example.com/collections/buildings/items/123.json'
+                rel: self
+                type: application/geo+json
+                title: this document
+              - href: 'https://data.example.com/collections/buildings/items/123.html'
+                rel: alternate
+                type: text/html
+                title: this document as HTML
+              - href: 'https://data.example.com/collections/buildings'
+                rel: collection
+                type: application/geo+json
+                title: the collection document
+            id: '123'
+            geometry:
+              type: Polygon
+              coordinates:
+                - ...
+            properties:
+              function: residential
+              floors: '2'
+              lastUpdate: '2015-08-01T12:34:56Z'
+        text/html:
+          schema:
+            type: string
+    InvalidParameter:
+      description: |-
+        A query parameter has an invalid value.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+        text/html:
+          schema:
+            type: string
+    NotFound:
+      description: |-
+        The requested resource does not exist on the server. For example, a path parameter had an incorrect value.
+    NotAcceptable:
+      description: |-
+        Content negotiation failed. For example, the `Accept` header submitted in the request did not support any of the media types supported by the server for the requested resource.
+    ServerError:
+      description: |-
+        A server error occurred.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+        text/html:
+          schema:
+            type: string

--- a/core/openapi/schemas/featureCollectionGeoJSON.yaml
+++ b/core/openapi/schemas/featureCollectionGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - FeatureCollection
+    const: FeatureCollection
   features:
     type: array
     items:

--- a/core/openapi/schemas/featureGeoJSON.yaml
+++ b/core/openapi/schemas/featureGeoJSON.yaml
@@ -6,8 +6,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - Feature
+    const: Feature
   geometry:
     oneOf:
       - type: null
@@ -17,9 +16,9 @@ properties:
       - object
       - null
   id:
-    oneOf:
-      - type: string
-      - type: integer
+    type:
+      - string
+      - integer
   links:
     type: array
     items:

--- a/core/openapi/schemas/geometrycollectionGeoJSON.yaml
+++ b/core/openapi/schemas/geometrycollectionGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - GeometryCollection
+    const: GeometryCollection
   geometries:
     type: array
     items:

--- a/core/openapi/schemas/linestringGeoJSON.yaml
+++ b/core/openapi/schemas/linestringGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - LineString
+    const: LineString
   coordinates:
     type: array
     minItems: 2

--- a/core/openapi/schemas/multilinestringGeoJSON.yaml
+++ b/core/openapi/schemas/multilinestringGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - MultiLineString
+    const: MultiLineString
   coordinates:
     type: array
     items:

--- a/core/openapi/schemas/multipointGeoJSON.yaml
+++ b/core/openapi/schemas/multipointGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - MultiPoint
+    const: MultiPoint
   coordinates:
     type: array
     items:

--- a/core/openapi/schemas/multipolygonGeoJSON.yaml
+++ b/core/openapi/schemas/multipolygonGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - MultiPolygon
+    const: MultiPolygon
   coordinates:
     type: array
     items:

--- a/core/openapi/schemas/pointGeoJSON.yaml
+++ b/core/openapi/schemas/pointGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - Point
+    const: Point
   coordinates:
     type: array
     minItems: 2

--- a/core/openapi/schemas/polygonGeoJSON.yaml
+++ b/core/openapi/schemas/polygonGeoJSON.yaml
@@ -5,8 +5,7 @@ required:
 properties:
   type:
     type: string
-    enum:
-      - Polygon
+    const: Polygon
   coordinates:
     type: array
     items:

--- a/core/standard/clause_3_references.adoc
+++ b/core/standard/clause_3_references.adoc
@@ -1,9 +1,9 @@
 == References
 The following normative documents contain provisions that, through reference in this text, constitute provisions of this document. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. For undated references, the latest edition of the normative document referred to applies.
 
-* [[OpenAPI30]] OpenAPI Initiative (OAI). **OpenAPI Specification 3.0** [online]. 2020 [viewed 2020-03-16]. The latest patch version at the time of publication of this standard was 3.0.3, available at http://spec.openapis.org/oas/v3.0.3
+* [[OpenAPI30]] OpenAPI Initiative (OAI). **OpenAPI Specification 3.0** [online]. 2020 [viewed 2024-11-04]. The latest patch version at the time of publication of this standard was 3.0.4, available at http://spec.openapis.org/oas/v3.0.4
 
-* [[OpenAPI31]] OpenAPI Initiative (OAI). **OpenAPI Specification 3.1** [online]. 2021 [viewed 2024-05-06]. The latest patch version at the time of publication of this standard was 3.1.0, available at http://spec.openapis.org/oas/v3.1.0
+* [[OpenAPI31]] OpenAPI Initiative (OAI). **OpenAPI Specification 3.1** [online]. 2021 [viewed 2024-11-04]. The latest patch version at the time of publication of this standard was 3.1.1, available at http://spec.openapis.org/oas/v3.1.1
 
 * [[rfc2818]] Internet Engineering Task Force (IETF). RFC 2818: **HTTP Over TLS** [online]. Edited by E. Rescorla. 2000 [viewed 2020-03-16]. Available at https://www.rfc-editor.org/rfc/rfc2818.html
 

--- a/extensions/transactions/create-replace-update-delete/examples/openapi/ogcapi-features-4-example1.yaml
+++ b/extensions/transactions/create-replace-update-delete/examples/openapi/ogcapi-features-4-example1.yaml
@@ -48,9 +48,9 @@ paths:
       operationId: getLandingPage
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/LandingPage'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/LandingPage'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
   '/conformance':
     get:
       tags:
@@ -62,9 +62,9 @@ paths:
       operationId: getConformanceDeclaration
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ConformanceDeclaration'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ConformanceDeclaration'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
   '/collections':
     get:
       tags:
@@ -73,9 +73,9 @@ paths:
       operationId: getCollections
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Collections'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/Collections'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
   '/collections/{collectionId}':
     get:
       tags:
@@ -84,14 +84,14 @@ paths:
         describe the feature collection with id `collectionId`
       operationId: describeCollection
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/collectionId'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Collection'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/Collection'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
   '/collections/{collectionId}/items':
     get:
       tags:
@@ -107,19 +107,19 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeatures
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/limit'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/bbox'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/datetime'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/limit'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/bbox'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/datetime'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Features'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/Features'
         '400':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/InvalidParameter'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
     post:
       summary: insert resource
       description: Adds a new resource to the API.  Use content negotiation to indicate the representation of the resource (e.g. GeoJSON).
@@ -127,20 +127,20 @@ paths:
       tags:
         - insert
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/collectionId'
       requestBody:
         description: The request body shall contain a representation of the resource to be added to this collection.
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/featureGeoJSON'
+              $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/schemas/featureGeoJSON'
       responses:
         '201':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Feature'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/Feature'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
   '/collections/{collectionId}/items/{featureId}':
     get:
       tags:
@@ -153,15 +153,15 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeature
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/featureId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/featureId'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/Feature'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/Feature'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
     put:
       summary: replace resource
       description: Replaces an existing resource.  Use content negotiation to indicate the representation of the resource (e.g. GeoJSON).
@@ -169,21 +169,21 @@ paths:
       tags:
         - update
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/featureId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/featureId'
       requestBody:
         description: The request body shall contain a representation of the replacement resource.
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/featureGeoJSON'
+              $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/schemas/featureGeoJSON'
       responses:
         '204':
            description: The resource was replaced.
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'
     delete:
       summary: delete resource
       description: Remove an existing resource.  
@@ -191,12 +191,12 @@ paths:
       tags:
         - delete
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/collectionId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/parameters/featureId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/collectionId'
+        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/parameters/featureId'
       responses:
         '204':
            description: The resource was deleted.
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/NotFound'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/responses/ServerError'
+          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/responses/ServerError'

--- a/proposals/search/openapi/schemas/parameter.yaml
+++ b/proposals/search/openapi/schemas/parameter.yaml
@@ -50,5 +50,5 @@ properties:
       description: additional links, e.g. to documentation or to the schema of the values
       type: array
       items:
-         $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/link'
+         $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/schemas/link'
 

--- a/proposals/search/standard/clause_10_parameterized-stored-query.adoc
+++ b/proposals/search/standard/clause_10_parameterized-stored-query.adoc
@@ -84,7 +84,7 @@ properties:
       description: additional links, e.g. to documentation or to the schema of the values
       type: array
       items:
-         $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/link'
+         $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/ogcapi-features-1-oas30.yaml#/components/schemas/link'
 ----
 
 [[clause-parameterized-stored-query-parameter-define]]


### PR DESCRIPTION
This is a follow-up to #948. For convenience, maintain schemas for both OpenAPI v3.0 and v3.1. Only Part 1 examples will use the v3.1 schema for now, others still use OpenAPI v3.0.