### PR TITLE
Schemas: remove CURIE references

### DIFF
--- a/extensions/schemas/standard/annex_bibliography.adoc
+++ b/extensions/schemas/standard/annex_bibliography.adoc
@@ -7,8 +7,6 @@
 
 [[ogc-link-relations]] Open Geospatial Consortium (OGC). **OGC Link Relation Type Register** [online, viewed 2023-10-14], Available at http://www.opengis.net/def/rel
 
-[[ogc-curies]] Open Geospatial Consortium (OGC). **OGC CURIE Register** [online, viewed 2023-10-14], Available at http://www.opengis.net/def/curie
-
 [[OpenAPI]] OpenAPI Initiative (OAI). **OpenAPI Specification 3.0** [online, viewed 2023-10-14]. 2020. Available at http://spec.openapis.org/oas/v3.0.3
 
 [[rfc6906]] Internet Engineering Task Force (IETF). RFC 6906: **The 'profile' Link Relation Type**. Edited by E. Wilde. 2013. Available at https://www.rfc-editor.org/rfc/rfc6906.html

--- a/extensions/schemas/standard/clause_10_returnables_and_receivables.adoc
+++ b/extensions/schemas/standard/clause_10_returnables_and_receivables.adoc
@@ -18,7 +18,7 @@ This requirements class supports clients that want to discover the list of resou
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |A Returnables and Receivables resource SHALL be referenced from all Collection resources with a link with the link relation type `\http://www.opengis.net/def/rel/ogc/1.0/schema` (or, alternatively, `[ogc-rel:schema]`).
+^|A |A Returnables and Receivables resource SHALL be referenced from all Collection resources with a link with the link relation type `\http://www.opengis.net/def/rel/ogc/1.0/schema`.
 |===
 
 :req: op

--- a/extensions/schemas/standard/clause_11_queryables.adoc
+++ b/extensions/schemas/standard/clause_11_queryables.adoc
@@ -22,7 +22,7 @@ In addition, a <<publisher-def,publisher>> may want to support <<queryable-def,q
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |A Queryables resource SHALL be referenced from all Collection resources with a link with the link relation type `\http://www.opengis.net/def/rel/ogc/1.0/queryables` (or, alternatively, `[ogc-rel:queryables]`).
+^|A |A Queryables resource SHALL be referenced from all Collection resources with a link with the link relation type `\http://www.opengis.net/def/rel/ogc/1.0/queryables`.
 |===
 
 :req: op

--- a/extensions/schemas/standard/clause_12_sortables.adoc
+++ b/extensions/schemas/standard/clause_12_sortables.adoc
@@ -22,7 +22,7 @@ In addition, a <<publisher-def,publisher>> may want to support <<sortable-def,so
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |A Sortables resource SHALL be referenced from all Collection resources with a link with the link relation type `\http://www.opengis.net/def/rel/ogc/1.0/sortables` (or, alternatively, `[ogc-rel:sortables]`).
+^|A |A Sortables resource SHALL be referenced from all Collection resources with a link with the link relation type `\http://www.opengis.net/def/rel/ogc/1.0/sortables`.
 |===
 
 :req: op

--- a/extensions/schemas/standard/clause_13_profile_parameter.adoc
+++ b/extensions/schemas/standard/clause_13_profile_parameter.adoc
@@ -39,9 +39,8 @@ explode: false
 ----
 ^|B |Each item SHALL be one of the follwoing:
 
-* A HTTP(S) URI of a profile, e.g., in the OGC Profile Register (\http://www.opengis.net/def/profile);
-* A Safe CURIE of a profile in the OGC Profile Register (e.g., `[ogc-profile:my-profile]`);
-* A profile identifier (the `profileId` value in the URI template `\http://www.opengis.net/def/profile/OGC/0/{profileId}`)
+* The profile identifier of a profile in the OGC Profile Register (the `profileId` value in the URI template `\http://www.opengis.net/def/profile/OGC/0/{profileId}`);
+* A HTTP(S) URI of a profile, e.g., in the OGC Profile Register (\http://www.opengis.net/def/profile).
 |===
 
 :per: profile-param-default

--- a/extensions/schemas/standard/clause_5_conventions.adoc
+++ b/extensions/schemas/standard/clause_5_conventions.adoc
@@ -18,9 +18,7 @@ The following OGC link relation types are introduced in this document (no applic
 * **\http://www.opengis.net/def/rel/ogc/1.0/queryables**: Refers to a resource that lists properties that can be used to filter sub-resources of the link's context.
 * **\http://www.opengis.net/def/rel/ogc/1.0/sortables**: Refers to a resource that lists properties that can be used to sort sub-resources of the link's context.
 
-As an alternative, the https://docs.ogc.org/pol/09-048r6.html#toc14[Compact URI (CURIE)], e.g., **[ogc-rel:schema]**, can also be used when a CURIE is an allowed value.
-
-NOTE: This link relation type needs to be registered in the <<ogc-link-relations,OGC Link Relation Type Register>> as well as in the <<ogc-curies,OGC CURIE Register>>. This note has to be removed before publication.
+NOTE: These link relation types need to be registered in the <<ogc-link-relations,OGC Link Relation Type Register>>. This note has to be removed before publication.
 
 === HTTP URIs
 


### PR DESCRIPTION
CURIEs are no longer needed. 

For the "profile" parameter there is a provision for a short code, when the profile has been registered with OGC.