### PR TITLE
Schemas: add note about "describedby" links

### DIFF
--- a/extensions/schemas/standard/clause_1_scope.adoc
+++ b/extensions/schemas/standard/clause_1_scope.adoc
@@ -1,8 +1,6 @@
 == Scope
 
-This Standard specifies an extension to the <<OAFeat-1,OGC API - Features - Part 1: Core>> Standard that defines the behavior of a server that provides information about the schema of the geospatial data, for example, of the features in each collection.
+This Standard specifies:
 
-This document specifies:
-
-* Schemas describing geospatial data; and
-* API building blocks for the support of schemas describing geospatial data in deployed Web APIs implementing one or more OGC API requirements classes.
+* Logical schemas describing geospatial data, for example, the properties of the features in a feature collection; and
+* API building blocks related to such schemas for use in OGC Web APIs.

--- a/extensions/schemas/standard/clause_5_conventions.adoc
+++ b/extensions/schemas/standard/clause_5_conventions.adoc
@@ -18,6 +18,10 @@ The following OGC link relation types are introduced in this document (no applic
 * **\http://www.opengis.net/def/rel/ogc/1.0/queryables**: Refers to a resource that lists properties that can be used to filter sub-resources of the link's context.
 * **\http://www.opengis.net/def/rel/ogc/1.0/sortables**: Refers to a resource that lists properties that can be used to sort sub-resources of the link's context.
 
+Note that links with the link relation type **\http://www.opengis.net/def/rel/ogc/1.0/schema** reference a logical schema that is independent of the representation of the data in some format. 
+
+For referencing a JSON Schema that can be used to validate, for example, a GeoJSON document, use a link with the IETF link relation type **describedby** to reference the JSON Schema that can be used to validate the document. The use of the link relation type **describedby** for linking to a JSON Schema for schema validation is recommended in the JSON Schema specification.
+
 As an alternative, the https://docs.ogc.org/pol/09-048r6.html#toc14[Compact URI (CURIE)], e.g., **[ogc-rel:schema]**, can also be used when a CURIE is an allowed value.
 
 NOTE: This link relation type needs to be registered in the <<ogc-link-relations,OGC Link Relation Type Register>> as well as in the <<ogc-curies,OGC CURIE Register>>. This note has to be removed before publication.


### PR DESCRIPTION
also updates the scope statement to clarify in the scope that logical schemas are the scope, not schemas for validating a specific representation of the data.

related to #928