### PR TITLE
Reword part of Req 27.

### DIFF
--- a/extensions/schemas/standard/clause_13_profile_parameter.adoc
+++ b/extensions/schemas/standard/clause_13_profile_parameter.adoc
@@ -40,7 +40,7 @@ explode: false
 ^|B |Each item SHALL be one of the follwoing:
 
 * The profile identifier of a profile in the OGC Profile Register (the `profileId` value in the URI template `\http://www.opengis.net/def/profile/OGC/0/{profileId}`);
-* A HTTP(S) URI of a profile
+* A HTTP(S) URI of a profile.
 |=== 
 
 NOTE: Profile URIs could be URIs from the OGC Profile Register (\http://www.opengis.net/def/profile) but they do not have to be.  For example, communities of interest can develop and document their our profile URIs without the involvement of OGC.

--- a/extensions/schemas/standard/clause_13_profile_parameter.adoc
+++ b/extensions/schemas/standard/clause_13_profile_parameter.adoc
@@ -40,8 +40,10 @@ explode: false
 ^|B |Each item SHALL be one of the follwoing:
 
 * The profile identifier of a profile in the OGC Profile Register (the `profileId` value in the URI template `\http://www.opengis.net/def/profile/OGC/0/{profileId}`);
-* A HTTP(S) URI of a profile, e.g., in the OGC Profile Register (\http://www.opengis.net/def/profile).
-|===
+* A HTTP(S) URI of a profile
+|=== 
+
+NOTE: Profile URIs could be URIs from the OGC Profile Register (\http://www.opengis.net/def/profile) but they do not have to be.  For example, communities of interest can develop and document their our profile URIs without the involvement of OGC.
 
 :per: profile-param-default
 [#{req-class}_{per}]


### PR DESCRIPTION
The current wording of [req 27](https://docs.ogc.org/DRAFTS/23-058r1.html#rc_profile-parameter) is leading people to think that profile URIs need to be registered in the OGC Profile Registry.  I've remove the example part for the second part of the requirement and added a note after the requirement that more fully describes the intent ... I hope.