### PR TITLE
Part 4: fix editorial link inconsistencies

### DIFF
--- a/extensions/transactions/create-replace-update-delete/standard/abstract_tests/ATS_class_patch-update.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/abstract_tests/ATS_class_patch-update.adoc
@@ -4,7 +4,7 @@
 2+|*Requirements Class*
 2+|http://www.opengis.net/spec/ogcapi-common-5/1.0/req/create-replace-delete/update
 |Target type |Web API
-|Dependency |<<rfc2616,RFC 2616 (HTTP/1.1)>>
+|Dependency |<<rfc9110,RFC 9110 (HTTP Semantics)>>
 |Dependency |<<rfc7396,RFC 7396 (JSON Merge Patch)>>
 |Dependency |<<rfc5261,RFC 5261 (An Extensible Markup Language (XML) Patch Operations Framework Utilizing XML Path Language (XPath) Selectors)>>
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/abstract_tests/ATS_class_simpletx.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/abstract_tests/ATS_class_simpletx.adoc
@@ -4,5 +4,5 @@
 2+|*Requirements Class*
 2+|http://www.opengis.net/spec/ogcapi-common-5/1.0/req/create-replace-delete
 |Target type |Web API
-|Dependency |<<rfc2616,RFC 2616 (HTTP/1.1)>>
+|Dependency |<<rfc9110,RFC 9110 (HTTP Semantics)>>
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/abstract_tests/simpletx/update/put/ATS_content-type.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/abstract_tests/simpletx/update/put/ATS_content-type.adoc
@@ -8,4 +8,4 @@
 ^|Test Method |
 |===
 
-((As per <<rfc2616,HTTP 1.1>> (https://www.rfc-editor.org/rfc/rfc2616.html#section-14.17) the 'Content-Type' header shall be used to indicate the media type of a request body containing a representation of the replacement resource.))
+((As per <<rfc9110,RFC 9110 (HTTP Semantics)>> (https://www.rfc-editor.org/rfc/rfc9110#field.content-type) the 'Content-Type' header shall be used to indicate the media type of a request body containing a representation of the replacement resource.))

--- a/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
@@ -24,7 +24,7 @@ resource encoding be supported by a server.
 
 NOTE: The use of the HTTP PATCH method is not defined in this requirements class.  The <<rc_update,Update>> requirements class defines the use of the HTTP PATCH method.
 
-NOTE: In order to promote interoperability, each OGC Standard that extends this Standard should make recommendations concerning the representation of resources.  See <<features,Features>> for a discussion of feature representations.
+NOTE: In order to promote interoperability, each OGC Standard that extends this Standard should make recommendations concerning the representation of resources.  See <<features_clause,Features>> for a discussion of feature representations.
 
 include::requirements/create-replace-delete/REQ_methods.adoc[]
 
@@ -266,7 +266,7 @@ include::../examples/json/ex04_delete.adoc[]
 
 ==== Overview
 
-A server is not required to implement every method described in this Standard (i.e. POST, PUT, <<update_clause,PATCH>> or DELETE) for every mutable resource that it offers.  Furthermore, a server that supports the ability to add, modify or remove resources from collections is not likely to be an open server.  That is, access to the server, and specifically the operations that allow resource creation, modification and/or removal, will be controlled.  Such controls might, for example, take the form of policy requirements (e.g. resources on this server can be inserted or updated but not deleted) or user access control requirements (e.g. user "X" is only allowed to create resources but not update or delete resources).  Regardless of the controls the server must be able to advertise, within the control context in place, which methods are available for each resource that it offers.  This is accomplished using the https://www.rfc-editor.org/rfc/rfc2616.html#section-9.2[HTTP OPTIONS] method.
+A server is not required to implement every method described in this Standard (i.e. POST, PUT, PATCH or DELETE) for every mutable resource that it offers.  Furthermore, a server that supports the ability to add, modify or remove resources from collections is not likely to be an open server.  That is, access to the server, and specifically the operations that allow resource creation, modification and/or removal, will be controlled.  Such controls might, for example, take the form of policy requirements (e.g. resources on this server can be inserted or updated but not deleted) or user access control requirements (e.g. user "X" is only allowed to create resources but not update or delete resources).  Regardless of the controls the server must be able to advertise, within the control context in place, which methods are available for each resource that it offers.  This is accomplished using the https://www.rfc-editor.org/rfc/rfc9110#OPTIONS[HTTP OPTIONS] method.
 
 The HTTP OPTIONS method allows the server to explicitly declare which HTTP methods are supported for a particular resource(s) endpoint.  This Standard deals with the HTTP POST, PUT, PATCH and DELETE methods but any relevant HTTP method may be listed for a particular resource.
 

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/create-replace-delete/create/REQ_body.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/create-replace-delete/create/REQ_body.adoc
@@ -1,4 +1,4 @@
-[[rec_create-replace-delete_post-body]]
+[[req_create-replace-delete_post-body]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/create-replace-delete/post-body*

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/create-replace-delete/create/REQ_content-type.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/create-replace-delete/create/REQ_content-type.adoc
@@ -1,4 +1,4 @@
-[[rec_create-replace-delete_post-content-type]]
+[[req_create-replace-delete_post-content-type]]
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/create-replace-delete/post-content-type*


### PR DESCRIPTION
- Remove the link to the Update clause on "PATCH" in the OPTIONS discussion; the sentence refers to the HTTP methods in general and the other methods (POST, PUT, DELETE) are not linked either.
- Update HTTP links to reference RFC 9110 (HTTP Semantics) instead of the obsolete RFC 2616, consistent with the rest of the document.
- Fix broken cross-reference <<features>> (the anchor is "features_clause").
- Fix anchors of two requirements that used a "rec_" prefix.

Closes #947