### PR TITLE
Part 4: clarify that PUT supports upserts

### DIFF
--- a/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
@@ -176,6 +176,8 @@ include::requirements/create-replace-delete/replace/REQ_put-op.adoc[]
 
 include::recommendations/create-replace-delete/replace/PER_create.adoc[]
 
+NOTE: If a server supports the PUT method on non-existing resources (Permission <<per_create-replace-delete_put-create,/per/create-replace-delete/put-create>>), the PUT method acts as an "upsert" operation: If a resource with the resource identifier stated in the request URI exists, the resource is replaced (update); otherwise, a new resource with that identifier is created (insert).
+
 ==== Request body
 
 ==== Overview 


### PR DESCRIPTION
Add a note to the Replace operation that PUT acts as an "upsert" (update or insert) operation, if the server supports the PUT method on non-existing resources (/per/create-replace-delete/put-create).

Closes #1008