### PR TITLE
Part 4: co-branding as OGC API - Common - Part 5

### DIFF
--- a/extensions/transactions/create-replace-update-delete/standard/20-002.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/20-002.adoc
@@ -1,5 +1,7 @@
-:Title: OGC API - Features - Part 4: Create, Replace, Update and Delete
-:titletext: OGC API - Features - Part 4: Create, Replace, Update and Delete
+:Title: OGC API - Features - Part 4 / OGC API - Common - Part 5: Create, Replace, Update and Delete
+:titletext: OGC API - Features - Part 4 / OGC API - Common - Part 5: Create, Replace, Update and Delete
+:standard: ogcapi-common-5
+:m_n: 1.0
 :doctype: book
 :encoding: utf-8
 :lang: en
@@ -29,9 +31,9 @@
 |Submission Date: <yyyy-mm-dd>
 |Approval Date:  <yyyy-mm-dd>
 |Publication Date:  <yyyy-mm-dd>
-|External identifier of this OGC(R) document: http://www.opengis.net/doc/IS/ogcapi-common-5/1.0
+|External identifier of this OGC(R) document: http://www.opengis.net/doc/IS/{standard}/{m_n}
 |Internal reference number of this OGC(R) document:    20-002r1
-|Version: 1.0.0-draft.2
+|Version: 1.0.0-draft.3
 |Latest Published Draft: n/a
 |Category: OGC(R) Implementation Standard
 |Editors: Panagiotis (Peter) A. Vretanos, Clemens Portele

--- a/extensions/transactions/create-replace-update-delete/standard/annex_history.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/annex_history.adoc
@@ -9,4 +9,5 @@
 |2020-06-02 |1.0.0-SNAPSHOT |P. Vretanos |all |reorganize to separate feature-specific aspects in its own requirements class
 |2024-03-07 |1.0.0-draft.1 |P. Vretanos, C. Portele |all |draft for OAB review
 |2024-06-04 |1.0.0-draft.2 |P. Vretanos, C. Portele |all |draft for Public Comment
+|2026-08-20 |1.0.0-draft.3 |P. Vretanos, C. Portele |all |co-branding as OGC API - Common - Part 5
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/clause_0_front_material.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_0_front_material.adoc
@@ -1,10 +1,14 @@
 [big]*i.     Abstract*
 
-OGC API standards define modular API building blocks to spatially enable Web APIs in a consistent way. The <<OpenAPI,OpenAPI specification>> is used to define the API building blocks.
+OGC API Standards define modular API building blocks to spatially enable Web API implementations in a consistent way. The <<OpenAPI,OpenAPI specification>> is used to define the API building blocks.
 
-OGC API - Common - Part 5 / Features - Part 4: Create, Replace, Update and Delete Standard (hereafter also referred to as "this Standard" or "this document") defines the behavior of an API that allows resource instances to be added, replaced, modified and/or removed for a collection of resources.
+OGC API - Features Standard defines building blocks to create, modify and query features on the Web. The OGC API - Features Standard is comprised of multiple parts. Each part is a separate standard.
 
-NOTE: This Standard was developed in the Features API SWG but is being written as a generic extension that is applicable to a variety of resource types including features.  The feature-specific portions of this extension are isolated to the clause titled <<features,Features>>.  It is anticipated that the bulk of this extension will eventually be moved into 'OGC API - Common' and only the feature-specific content will remain to be managed by the Features API SWG.
+Some API building blocks are applicable in multiple OGC API Standards. These common building blocks are documented in the OGC API — Common Standard, which is comprised of multiple parts, too.
+
+This document ("Create, Replace, Update and Delete") defines the behavior of a Web API that allows resource instances to be added, replaced, modified and/or removed for a collection of resources. The document is published both as Part 4 of OGC API - Features and as Part 5 of OGC API - Common. This document is hereafter also referred to as "this Standard".
+
+The provisions of this Standard are generic and applicable to a variety of resource types, not just features. The feature-specific provisions are isolated in the requirements class <<features_clause,Features>>.
 
 [big]*ii.    Keywords*
 

--- a/extensions/transactions/create-replace-update-delete/standard/clause_2_conformance.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_2_conformance.adoc
@@ -17,10 +17,10 @@ The URIs of the associated conformance classes are:
 [cols="25,75",options="header"]
 |===
 |Conformance class |URI
-|Create/Replace/Delete |http://www.opengis.net/spec/ogcapi-common-5/1.0/conf/create-replace-delete
-|Update |http://www.opengis.net/spec/ogcapi-common-5/1.0/conf/update
-|Optimistic Locking using Timestamps |http://www.opengis.net/spec/ogcapi-common-5/1.0/req/optimistic-locking-timestamps
-|Optimistic Locking using ETags |http://www.opengis.net/spec/ogcapi-common-5/1.0/req/optimistic-locking-etags
+|Create/Replace/Delete |http://www.opengis.net/spec/{standard}/{m_n}/conf/create-replace-delete
+|Update |http://www.opengis.net/spec/{standard}/{m_n}/conf/update
+|Optimistic Locking using Timestamps |http://www.opengis.net/spec/{standard}/{m_n}/conf/optimistic-locking-timestamps
+|Optimistic Locking using ETags |http://www.opengis.net/spec/{standard}/{m_n}/conf/optimistic-locking-etags
 |Features |http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/features
 |===
 

--- a/extensions/transactions/create-replace-update-delete/standard/clause_5_conventions.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_5_conventions.adoc
@@ -6,7 +6,7 @@ See <<OAFeat-1,OGC API - Features - Part 1: Core>>, Clauses 5 and 6.
 
 === Identifiers
 
-The normative provisions in this Standard applicable to multiple OGC API Standards are denoted by the URI `http://www.opengis.net/spec/ogcapi-common-5/1.0`.
+The normative provisions in this Standard applicable to multiple OGC API Standards are denoted by the URI `http://www.opengis.net/spec/{standard}/{m_n}`.
 
 The normative provisions in this Standard specific to OGC API - Features are denoted by the URI `http://www.opengis.net/spec/ogcapi-features-4/1.0`.
 

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_create-replace-delete.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_create-replace-delete.adoc
@@ -2,7 +2,7 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class*
-2+|http://www.opengis.net/spec/ogcapi-common-5/1.0/req/create-replace-delete
+2+|http://www.opengis.net/spec/{standard}/{m_n}/req/create-replace-delete
 |Target type |Web API
 |Dependency |<<rfc9110,RFC 9110 (HTTP Semantics)>>
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_optimistic-locking-etags.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_optimistic-locking-etags.adoc
@@ -2,6 +2,6 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class*
-2+|http://www.opengis.net/spec/ogcapi-common-5/1.0/req/optimistic-locking-etags
+2+|http://www.opengis.net/spec/{standard}/{m_n}/req/optimistic-locking-etags
 |Target type |Web API
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_optimistic-locking-timestamps.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_optimistic-locking-timestamps.adoc
@@ -2,6 +2,6 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class*
-2+|http://www.opengis.net/spec/ogcapi-common-5/1.0/req/optimistic-locking-timestamps
+2+|http://www.opengis.net/spec/{standard}/{m_n}/req/optimistic-locking-timestamps
 |Target type |Web API
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_update.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_update.adoc
@@ -2,7 +2,7 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class*
-2+|http://www.opengis.net/spec/ogcapi-common-5/1.0/req/update
+2+|http://www.opengis.net/spec/{standard}/{m_n}/req/update
 |Target type |Web API
 |Dependency |<<rfc5789,RFC 5789 (PATCH Method for HTTP)>>
 |===


### PR DESCRIPTION
Complete the mechanical part of the co-branding, following the approach of the Schemas standard (Features Part 5 / Common Part 3):

- Use the dual title "OGC API - Features - Part 4 / OGC API - Common - Part 5: Create, Replace, Update and Delete".
- Add document attributes "standard" (ogcapi-common-5) and "m_n" (1.0) and use them in the URIs of the generic requirements/ conformance classes; the "Features" requirements class continues to use ogcapi-features-4 URIs.
- Rewrite the abstract to describe the co-publication as part of both OGC API - Features and OGC API - Common, replacing the note that anticipated a future move to OGC API - Common.
- Fix the conformance class URIs of the two Optimistic Locking classes to use /conf/ instead of /req/.

The generalization of feature/collection-specific language in the generic requirements classes is handled separately (see #1022).