### PR TITLE
Part 4: clarify media types in mutation requests

### DIFF
--- a/extensions/transactions/create-replace-update-delete/standard/clause_10_media_types.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_10_media_types.adoc
@@ -5,6 +5,8 @@ See <<OAFeat-1,OGC API - Features - Part 1: Core>>, Clause 10.
 
 The media types for the CREATE, REPLACE and UPDATE requests as well as for the schema documents depend on the representations of the resources.
 
+NOTE: Schema documents are listed, too, because clients will often use the schema information about the resources in a collection to construct the content of CREATE, REPLACE, and UPDATE requests that are acceptable to the server. See <<schemas,Feature schemas>> for details.
+
 For GeoJSON features,
 
 - CREATE and REPLACE operations will use `application/geo+json`,
@@ -16,3 +18,5 @@ For GML features,
 - CREATE and REPLACE operations will use `application/gml+xml`,
 - UPDATE operations will use `application/xml`,
 - schema documents will use `application/xml`.
+
+These media types identify the specific representations and clients should use them in the `Content-Type` header of CREATE, REPLACE and UPDATE requests. A server may, however, be lenient and also accept a more generic media type, if the server can determine the specific representation from the content of the request body. For example, a server may accept `application/json` for a feature that is represented as GeoJSON in a CREATE request. See Permissions <<per_create-replace-delete_content-type-lenient,/per/create-replace-delete/content-type-lenient>> and <<per_update_content-type-lenient,/per/update/content-type-lenient>>.

--- a/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
@@ -20,7 +20,11 @@ Finally, the HTTP DELETE method is used to remove a resource from a collection.
 
 Adding or replacing a resource requires that a representation of that resource
 be provided by the client.  This Standard does not mandate that a specific
-resource encoding be supported by a server.
+resource encoding be supported by a server. The client declares the media type
+of the resource representation in the request body in the `Content-Type` header
+(see <<mediatypes,Media Types>>).
+
+include::recommendations/create-replace-delete/PER_content-type-lenient.adoc[]
 
 NOTE: The use of the HTTP PATCH method is not defined in this requirements class.  The <<rc_update,Update>> requirements class defines the use of the HTTP PATCH method.
 

--- a/extensions/transactions/create-replace-update-delete/standard/clause_7_update.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_7_update.adoc
@@ -10,7 +10,9 @@ A server that implements this requirements class provides the ability to use
 the HTTP PATCH method to modify parts of an existing resource without the need
 to transmit a complete replacement resource.
 
-Modifying parts of a resource requires that a document describing the changes to be applied be provided by the client.  This Standard does not mandate that a specific encoding for this document be supported by a server.
+Modifying parts of a resource requires that a document describing the changes to be applied be provided by the client.  This Standard does not mandate that a specific encoding for this document be supported by a server. The client declares the media type of the document in the request body in the `Content-Type` header (see <<mediatypes,Media Types>>).
+
+include::recommendations/update/PER_content-type-lenient.adoc[]
 
 include::requirements/update/REQ_methods.adoc[]
 

--- a/extensions/transactions/create-replace-update-delete/standard/recommendations/create-replace-delete/PER_content-type-lenient.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/recommendations/create-replace-delete/PER_content-type-lenient.adoc
@@ -1,0 +1,6 @@
+[[per_create-replace-delete_content-type-lenient]]
+[width="90%",cols="2,6a"]
+|===
+^|*Permission {counter:per-id}* |*/per/create-replace-delete/content-type-lenient*
+^|A |In addition to the media types of the supported resource representations (for example, `application/geo+json` for features represented as GeoJSON), a server MAY accept a more generic media type (for example, `application/json`) in the `Content-Type` header of a request, if the server can unambiguously determine the specific representation of the resource from the content of the request body.
+|===

--- a/extensions/transactions/create-replace-update-delete/standard/recommendations/update/PER_content-type-lenient.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/recommendations/update/PER_content-type-lenient.adoc
@@ -1,0 +1,6 @@
+[[per_update_content-type-lenient]]
+[width="90%",cols="2,6a"]
+|===
+^|*Permission {counter:per-id}* |*/per/update/content-type-lenient*
+^|A |In addition to the media types of the supported encodings of documents describing changes (for example, `application/merge-patch+json`), a server MAY accept a more generic media type (for example, `application/json`) in the `Content-Type` header of a request, if the server can unambiguously determine the specific encoding of the document from the content of the request body.
+|===


### PR DESCRIPTION
As discussed in the SWG meetings on 2024-08-26 and 2025-03-24, the Standard uses the proper media types of the specific resource representations, but implementations can be more lenient and also accept generic media types like application/json, if the specific representation can be determined from the content of the request body. This is now stated explicitly in two permissions (Create/Replace/Delete and Update) and in the Media Types clause. 

The Media Types clause also explains why schema document media types are listed. 

Closes #943