### PR TITLE
Part 4: declare JSON-FG extensions in GeoJSON request bodies

### DIFF
--- a/extensions/transactions/create-replace-update-delete/standard/clause_3_references.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_3_references.adoc
@@ -4,7 +4,9 @@ The following normative documents contain provisions that, through reference in 
 
 * [[rfc5789]] Internet Engineering Task Force (IETF). RFC 5789: **PATCH Method for HTTP** [online]. Edited by L. Dusseault, J. Snell. 2010 [viewed 2021-01-25]. Available at https://www.rfc-editor.org/rfc/rfc5789
 * [[rfc7396]] Internet Engineering Task Force (IETF). RFC 7396: **JSON Merge Patch** [online]. Edited by P. Hoffman, J. Snell. 2014 [viewed 2021-01-25]. Available at https://www.rfc-editor.org/rfc/rfc7396
+* [[rfc6906]] Internet Engineering Task Force (IETF). RFC 6906: **The 'profile' Link Relation Type** [online]. Edited by E. Wilde. 2013 [viewed 2026-08-20]. Available at https://www.rfc-editor.org/rfc/rfc6906
 * [[rfc9110]] Internet Engineering Task Force (IETF). RFC 9110: **HTTP Semantics** [online]. Edited by R. Fielding, J. Reschke,  M. Nottingham. 2022 [viewed 2022-11-06]. Available at https://www.rfc-editor.org/rfc/rfc9110
+* [[JSON-FG]] Open Geospatial Consortium (OGC). **OGC Features and Geometries JSON - Part 1: Core 1.0** [online]. Edited by C. Portele, P. Vretanos. 2026 [viewed 2026-08-20]. Available at https://www.opengis.net/doc/IS/json-fg-1/1.0
 * [[OAFeat-1]] Open Geospatial Consortium (OGC). **OGC API - Features - Part 1: Core 1.0** [online]. Edited by C. Portele, P. Vretanos, C. Heazel. 2019 [viewed 2020-05-24]. Available at http://www.opengis.net/doc/IS/ogcapi-features-1/1.0
 * [[OAFeat-2]] Open Geospatial Consortium (OGC). **OGC API - Features - Part 2: Coordinate Reference Systems by Reference 1.0** [online]. Edited by C. Portele, P. Vretanos. 2020 [viewed 2020-12-03]. Available at http://www.opengis.net/doc/IS/ogcapi-features-2/1.0
 * [[OAFeat-5]] Open Geospatial Consortium (OGC). **OGC API - Features - Part 5 / OGC API - Common - Part 3: Schemas 1.0** [online]. Edited by C. Portele, P. Vretanos. 2026 [viewed 2023-12-28]. Available at https://www.opengis.net/doc/IS/ogcapi-common-3/1.0

--- a/extensions/transactions/create-replace-update-delete/standard/clause_9_features.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_9_features.adoc
@@ -98,7 +98,23 @@ include::recommendations/features/PER_other_update_vocabs.adoc[]
 
 include::requirements/features/REQ_geojson-create-replace.adoc[]
 
-GeoJSON normatively supports WGS84 longitude/latitude, but the https://www.rfc-editor.org/rfc/rfc7946.html#section-4["prior arrangement" provision] allows that other CRSs can be used if both client and server agree on the CRS. Clients that want to use a CRS that is not the default CRS have to state the CRS in the POST, PUT or PATCH request using the `Content-Crs` HTTP header to invoke the "prior arrangement" provision. 
+GeoJSON normatively supports WGS84 longitude/latitude, but the https://www.rfc-editor.org/rfc/rfc7946.html#section-4["prior arrangement" provision] allows that other CRSs can be used if both client and server agree on the CRS. Clients that want to use a CRS that is not the default CRS have to state the CRS in the POST, PUT or PATCH request using the `Content-Crs` HTTP header to invoke the "prior arrangement" provision.
+
+[[feature-geojson-jsonfg]]
+==== JSON-FG extensions
+
+<<JSON-FG,OGC Features and Geometries JSON (JSON-FG)>> extends GeoJSON with additional capabilities, for example, support for coordinate reference systems other than WGS 84 longitude/latitude or for solid geometries. JSON-FG feature representations use the same media type as GeoJSON (`application/geo+json`). JSON-FG defines GeoJSON profiles to distinguish the different representations.
+
+To declare in a POST, PUT or PATCH request that the request body is GeoJSON with JSON-FG extensions, the request includes a link with the link relation type `profile` (<<rfc6906,RFC 6906>>) and the URI of a JSON-FG profile in the `Link` header. For example, in a POST or PUT request:
+
+....
+Content-Type: application/geo+json
+Link: <http://www.opengis.net/def/profile/OGC/0/jsonfg>; rel=profile
+....
+
+include::requirements/features/REQ_geojson-jsonfg.adoc[]
+
+NOTE: Since the root object of a feature representation with JSON-FG extensions includes a "conformsTo" member, a server can also identify JSON-FG content by inspecting the request body, if no profile link is included in the request.
 
 [[feature-gml]]
 === Geography Markup Language (GML)

--- a/extensions/transactions/create-replace-update-delete/standard/clause_9_features.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_9_features.adoc
@@ -105,6 +105,8 @@ GeoJSON normatively supports WGS84 longitude/latitude, but the https://www.rfc-e
 
 <<JSON-FG,OGC Features and Geometries JSON (JSON-FG)>> extends GeoJSON with additional capabilities, for example, support for coordinate reference systems other than WGS 84 longitude/latitude or for solid geometries. JSON-FG feature representations use the same media type as GeoJSON (`application/geo+json`). JSON-FG defines GeoJSON profiles to distinguish the different representations.
 
+A server that supports JSON-FG implements the JSON-FG requirements class "JSON-FG in Web APIs" and declares this by including the conformance class `http://www.opengis.net/spec/json-fg-1/1.0/conf/api` in its conformance declaration. This enables clients to determine from the API itself that JSON-FG extensions can be used in request bodies.
+
 To declare in a POST, PUT or PATCH request that the request body is GeoJSON with JSON-FG extensions, the request includes a link with the link relation type `profile` (<<rfc6906,RFC 6906>>) and the URI of a JSON-FG profile in the `Link` header. For example, in a POST or PUT request:
 
 ....

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/features/REQ_geojson-jsonfg.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/features/REQ_geojson-jsonfg.adoc
@@ -1,0 +1,9 @@
+[[req_features_geojson-jsonfg]]
+[width="90%",cols="2,6a"]
+|===
+^|*Requirement {counter:req-id}* |*/req/features/geojson-jsonfg*
+^|Condition |Server implements <<OAFeat-1,OGC API - Features - Part 1: Core, Requirements Class "GeoJSON">>
+^|Condition |Server supports <<JSON-FG,JSON-FG>> extensions in request bodies of CREATE, REPLACE, or UPDATE requests for a feature collection `collectionId`
+^|A |The server SHALL accept a link with the link relation type `profile` (<<rfc6906,RFC 6906>>) in the `Link` header of a CREATE, REPLACE, or UPDATE request to declare the GeoJSON profile of the feature representation in the request body, where the target of the link is one of `http://www.opengis.net/def/profile/OGC/0/rfc7946`, `http://www.opengis.net/def/profile/OGC/0/jsonfg`, or `http://www.opengis.net/def/profile/OGC/0/jsonfg-plus`.
+^|B |If the declared profile is `http://www.opengis.net/def/profile/OGC/0/jsonfg` or `http://www.opengis.net/def/profile/OGC/0/jsonfg-plus`, the server SHALL process the feature representation in the request body according to <<JSON-FG,OGC Features and Geometries JSON - Part 1: Core>>.
+|===

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/features/REQ_geojson-jsonfg.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/features/REQ_geojson-jsonfg.adoc
@@ -3,7 +3,7 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/features/geojson-jsonfg*
 ^|Condition |Server implements <<OAFeat-1,OGC API - Features - Part 1: Core, Requirements Class "GeoJSON">>
-^|Condition |Server supports <<JSON-FG,JSON-FG>> extensions in request bodies of CREATE, REPLACE, or UPDATE requests for a feature collection `collectionId`
+^|Condition |Server implements <<JSON-FG,OGC Features and Geometries JSON - Part 1: Core, Requirements Class "JSON-FG in Web APIs">>
 ^|A |The server SHALL accept a link with the link relation type `profile` (<<rfc6906,RFC 6906>>) in the `Link` header of a CREATE, REPLACE, or UPDATE request to declare the GeoJSON profile of the feature representation in the request body, where the target of the link is one of `http://www.opengis.net/def/profile/OGC/0/rfc7946`, `http://www.opengis.net/def/profile/OGC/0/jsonfg`, or `http://www.opengis.net/def/profile/OGC/0/jsonfg-plus`.
 ^|B |If the declared profile is `http://www.opengis.net/def/profile/OGC/0/jsonfg` or `http://www.opengis.net/def/profile/OGC/0/jsonfg-plus`, the server SHALL process the feature representation in the request body according to <<JSON-FG,OGC Features and Geometries JSON - Part 1: Core>>.
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_features.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_features.adoc
@@ -11,6 +11,8 @@
 |Conditional Dependency |<<OAFeat-1,OGC API - Features - Part 1: Core, Requirements Class "Geography Markup Language (GML), Simple Features Profile, Level 2">>
 |Conditional Dependency |<<update_clause>>
 |Conditional Dependency |<<rfc7396,RFC 7396 (JSON Merge Patch)>>
+|Conditional Dependency |<<rfc6906,RFC 6906 (The 'profile' Link Relation Type)>>
 |Conditional Dependency |<<OAFeat-2,OGC API - Features - Part 2: Coordinate Reference Systems by Reference>>
 |Conditional Dependency |<<OAFeat-5,OGC API - Features / OGC API - Common - Part 5: Schemas, Requirements Class "Returnables and Receivables">>
+|Conditional Dependency |<<JSON-FG,OGC Features and Geometries JSON - Part 1: Core>>
 |===

--- a/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_features.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/requirements/requirements_class_features.adoc
@@ -14,5 +14,5 @@
 |Conditional Dependency |<<rfc6906,RFC 6906 (The 'profile' Link Relation Type)>>
 |Conditional Dependency |<<OAFeat-2,OGC API - Features - Part 2: Coordinate Reference Systems by Reference>>
 |Conditional Dependency |<<OAFeat-5,OGC API - Features / OGC API - Common - Part 5: Schemas, Requirements Class "Returnables and Receivables">>
-|Conditional Dependency |<<JSON-FG,OGC Features and Geometries JSON - Part 1: Core>>
+|Conditional Dependency |<<JSON-FG,OGC Features and Geometries JSON - Part 1: Core, Requirements Class "JSON-FG in Web APIs">>
 |===


### PR DESCRIPTION
As decided in the 2025-10-06 meeting, adds a sub-section on JSON-FG extensions to the GeoJSON section: a link with the link relation type 'profile' (RFC 6906) and the URI of a JSON-FG profile in the Link header of a POST, PUT or PATCH request declares that the request body is GeoJSON with JSON-FG extensions, consistent with the use of profiles when querying features. Includes a new conditional requirement /req/features/geojson-jsonfg and normative references to JSON-FG Part 1 and RFC 6906. 

Closes #1024
