### PR TITLE
Re-add content that was over-written due to merge conflict resolution.

### DIFF
--- a/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
+++ b/extensions/transactions/create-replace-update-delete/standard/clause_6_create-replace-delete.adoc
@@ -321,7 +321,19 @@ include::recommendations/create-replace-delete/options/PER_res-body.adoc[]
 
 ==== HTTP Link Hints
 
-Managing transactional capabilities requires clients to dynamically discover what mutation operations and encodings an endpoint supports. While HTTP `OPTIONS` responses traditionally convey supported methods and characteristics through header fields such as `Allow` or `Accept-Post`, returning a response body with a `self` link to the resource can provide a standardized, machine-readable representation of endpoint capabilities. The hint vocabulary specified in the <<link-hints,HTTP Link Hints>> Internet-Draft is a candidate for additional information to include in such a link. Link hints are target attributes of a web link. A link serialization has to be selected. Examples are a JSON object with a `links` member with an array that includes a `self` link to the resource, with the hints as additional members of that link object, or the `application/link-format` media type specified in <<rfc6690,RFC 6690>>. Hint values are expressed using HTTP Structured Fields; the value of every hint mentioned below is a list of strings, which maps to a JSON array of strings.
+Managing transactional capabilities requires clients to dynamically discover what mutation operations and encodings an endpoint supports. 
+
+While HTTP `OPTIONS` responses traditionally convey supported methods and characteristics through header fields such as `Allow` or `Accept-Post`, returning a response body with a `self` link to the resource can provide a standardized, machine-readable representation of endpoint capabilities. 
+
+The hint vocabulary specified in the <<link-hints,HTTP Link Hints>> Internet-Draft is a candidate for additional information to include in such a link. 
+
+Link hints are target attributes of a web link. 
+
+A link serialization has to be selected. 
+
+Examples are a JSON object with a `links` member with an array that includes a `self` link to the resource, with the hints as additional members of that link object, or the `application/link-format` media type specified in <<rfc6690,RFC 6690>>.
+
+Hint values are expressed using HTTP Structured Fields; the value of every hint mentioned below is a list of strings, which maps to a JSON array of strings.
 
 In this context, issuing an `OPTIONS` request against a feature collection (`/collections/{collectionId}/items`) or an individual feature resource (`/collections/{collectionId}/items/{featureId}`) yields a structured link detailing allowed interactions before a mutation is attempted.
 
@@ -337,6 +349,12 @@ Hints that are relevant to the operations specified in this Standard include:
 Link hints are advisory. As stated in the Internet-Draft, they are not a contract and the behavior of the resource at the time of the request always overrides the hinted information. A client can use hints to select an acceptable media type or to avoid a request that the server is known not to support, which reduces the number of round trips, but it still has to handle error responses.
 
 The Internet-Draft also establishes an IANA registry for link hints, so that the vocabulary can be extended. A hint that declares the coordinate reference systems in which a server accepts geometries in CREATE, REPLACE, and UPDATE requests — in particular, a restriction to the `storageCrs` of the collection, see Recommendation <<rec_features_crs-storage-crs,/rec/features/crs/storage-crs>> — would be a candidate for such an extension. Since this is not specific to features, any normative provision would be specified in a future version of this Standard or in a general OGC API Standard, once the Internet-Draft has been published as an RFC.
+
+==== Cross-origin requests
+
+General HTTP discovery and cross-origin requests can be combined into a single HTTP OPTIONS request that includes the standard CORS preflight request headers (`Origin` and `Access-Control-Request-Method`) while targeting the specific resource URI.  When the server handles this request, it satisfies the CORS preflight verification by returning the `Access-Control-Allow-Origin` and `Access-Control-Allow-Methods` headers, and simultaneously answers the general HTTP method discovery requirement by returning the standard `Allow` response header (e.g., Allow: GET, POST, PUT, OPTIONS) along with a 200 OK or 204 No Content status code. Combining the CORS-specific access control headers with the native HTTP Allow header in the single OPTIONS response allows the client to verify both cross-origin permissions and all supported methods for that resource in one round-trip.
+
+NOTE: Servers may need to use the `Access-Control-Expose-Headers` response header to whitelist which headers client-side JavaScript is permitted to read.  When using the OPTIONS method for HTTP discovery, this allows the client to access the `Allow` header (e.g. `Access-Control-Expose-Headers: Allow`).
 
 ==== Exceptions
 


### PR DESCRIPTION
Resolving a merge conflict for PR #1075 over wrote the content about CORS added in PR #1076.  This PR re-adds that content.